### PR TITLE
Update and rename RL_docs_apache_sites-enabled.md to apache-sites-ena…

### DIFF
--- a/en/rocky/8/guides/apache-sites-enabled.md
+++ b/en/rocky/8/guides/apache-sites-enabled.md
@@ -1,4 +1,8 @@
-# Advanced Docs Example: Apache Web Server Multi-Site Setup
+---
+title: 'Apache Web Server Multi-Site Setup'
+---
+
+# Apache Web Server Multi-Site Setup
 
 Rocky Linux has many ways for you to setup a web site. This is just one method, using Apache, and is designed for use as a multi-site setup on a single server. While this method is designed for multi-site servers, it can also act as a base configuration for a single site server as well. 
 
@@ -47,7 +51,7 @@ So we first need to create this configuration file in *sites-available*: `vi /et
 
 The configuration file configuration content would be something like this:
 
-```
+```apache
 <VirtualHost *:80>
         ServerName www.wiki.com 
         ServerAdmin username@rockylinux.org


### PR DESCRIPTION
This is to make it a bit more compatible with the docs.rockylinux.org page

```md
---
title: 'The Title of the Guide/Manual Page'
---

...
```

This snippet must be present at the start of every documentation file (all the `.md`/`.mdx` files) -- it sets the title in the metadata and the page title.

Other than that, docs.rockylinux.org repo is good to go. Just need more content. :)

I'll be putting in auto-building config to this repo soon.