### PR TITLE
Vsftpd should be a stand-alone document

### DIFF
--- a/en/rocky/8/guides/apache_hardened_webserver.md
+++ b/en/rocky/8/guides/apache_hardened_webserver.md
@@ -26,7 +26,7 @@ You might elect to use a couple of these tools and not the others, so for clarit
 * A Web-based Application Firewall (WAF), with _mod\_security_ rules [Apache Hardened Web Server - mod_security](apache_hardened_webserver_modsecurity.md)
 * Rootkit Hunter (rkhunter): A scan tool that checks against Linux malware [Apache Hardened Web Server - rkhunter](apache_hardened_webserver_rkhunter.md)
 * Database security (we are using _mariadb-server_ here) [Apache Hardened Web Server - mariadb-server](apache_hardened_webserver_mariadb-server.md)
-* A secure FTP or SFTP server (we are using _vsftpd_ here) [Apache Hardened Web Server - vsftpd](apache_hardened_webserver_vsftpd.md)
+* A secure FTP or SFTP server (we are using _vsftpd_ here) [Secure FTP Server - vsftpd](secure_ftp_server_vsftpd.md)
 
 This procedure does not replace the [Apache Web Server Multi-Site Setup](apache-sites-enabled.md), it simply adds these security elements to it. If you haven't read it, take some time to look at it before proceeding.
 

--- a/en/rocky/8/guides/secure_ftp_server_vsftpd.md
+++ b/en/rocky/8/guides/secure_ftp_server_vsftpd.md
@@ -1,9 +1,8 @@
-# Apache Hardened Web Server - vsftpd
+# Secure FTP Server - vsftpd
 
 
 # Prerequisites
 
-* A Rocky Linux Web Server running Apache
 * Proficiency with a command-line editor (we are using _vi_ in this example)
 * A heavy comfort level with issuing commands from the command-line, viewing logs, and other general systems administrator duties
 * An understanding of PAM, as well as _openssl_ commands is helpful.
@@ -14,10 +13,6 @@
 _vsftpd_ is the  Very Secure FTP Daemon (FTP being the file transfer protocol). It has been available for many years now, and is actually the default FTP daemon in Rocky Linux, as well as many other Linux distributions. 
 
 _vsftpd_ allows for the use of virtual users with pluggable authentication modules (PAM). These virtual users don't exist in the system, and have no other permissions except to use FTP. This means that if a virtual user gets compromised, the person with those credentials would have no other permissions once they gained access. Using this setup is very secure indeed, but does require a bit of extra work. 
-
-_vsftpd_ is just one possible component of a hardened Apache web server setup, and can be used with or without other tools. If you'd like to use this along with other tools for hardening, refer back to our [Apache Hardened Web Server guide](apache_hardened_webserver.md). 
-
-This document also uses all of the same assumptions and conventions outlined in that original document, so it is a good idea to review it before continuing.
 
 ## Installing vsftpd
 
@@ -47,7 +42,7 @@ Make sure that local_enable is set to yes:
 
 `local_enable=YES`
 
-Add a line for the local root user. We are assuming that you are using the configuration directory setup as specified in the [Apache Web Server Multi-Site Setup](apache-sites-enabled.md). If your setup is different, adjust the local_root setting:
+Add a line for the local root user. If the server that you are installing this on is a web server, we assume that you will be using the [Apache Web Server Multi-Site Setup](apache-sites-enabled.md), and that your local root will reflect that. If your setup is different, or if this is not a web server, adjust the local_root setting:
 
 `local_root=/var/www/sub-domains`
 
@@ -126,7 +121,7 @@ Next is the organizational unit name. You can fill this in if the server is for 
 
 `Organizational Unit Name (eg, section) []:`
 
-The next field should be filled in, however you can decide how you want to fill it in. This is the common name of your server. You might want to differentiate this from the web server name by perhaps calling it "webftp". Example: `webftp.domainname.ext`:
+The next field should be filled in, however you can decide how you want to fill it in. This is the common name of your server. Example: `webftp.domainname.ext`:
 
 `Common Name (eg, your name or your server's hostname) []:`
 
@@ -257,6 +252,6 @@ If you are unable to upload a file, then you may need to go back and make sure t
 
 # Conclusions
 
-_vsftpd_ is just another tool in a hardened web server setup. If set up to use virtual users and a certificate, it is quite secure. 
+_vsftpd_ is a popular and common ftp server and can be set up as a stand alone server, or as part of an [Apache Hardened Web Server](apache_hardened_webserver.md). If set up to use virtual users and a certificate, it is quite secure. 
 
 While there are quite a number of steps to setting up _vsftpd_ as outlined in this document, taking the extra time to set it up correctly will ensure that your server is as secure as it can be.


### PR DESCRIPTION
Per discussion with Wale, the _vsftpd_ server should be stand-alone. It
isn't necessarily required to only be installed on a web server. To add
clarity, deleted the old named file
(apache_hardened_webserver_vsftpd.md) and saved the file as
secure_ftp_server_vsftpd.md. This required editing the
apache_hardened_webserver.md main document to change the link to the ftp
server process.

The secure_ftp_server_vsftpd.md also reworded the document so that it
did not specify use on a web server, but also included using it on a web
server as an option.

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ? Yes.
- [x] Is this a non-English contribution? No
- [x] Title and Author MetaTags have been inserted into the document No.
- [x] If applicable, steps and instructions have been tested to work on a real system Yes.
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness Yes.


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

