### PR TITLE
Remove "Rocky Linux" from titles

### DIFF
--- a/en/rocky/8/guides/mirroring_lsyncd.md
+++ b/en/rocky/8/guides/mirroring_lsyncd.md
@@ -1,4 +1,4 @@
-# Rocky Linux - Mirroring Solution - lsycnd
+# Mirroring Solution - lsycnd
 
 ## Prerequisites
 

--- a/en/rocky/8/guides/rsnapshot_backup.md
+++ b/en/rocky/8/guides/rsnapshot_backup.md
@@ -1,4 +1,4 @@
-# Rocky Linux - Backup Solution - Rsnapshot
+# Backup Solution - Rsnapshot
 
 ## Prerequisites
 

--- a/en/rocky/8/guides/ssh_public_private_keys.md
+++ b/en/rocky/8/guides/ssh_public_private_keys.md
@@ -1,4 +1,4 @@
-# Rocky Linux - SSH Public and Private Key
+# SSH Public and Private Key
 
 ## Prerequisites
 


### PR DESCRIPTION
Thought I had all of these stripped away, but found three in a review.
This commit removes the "Rocky Linux" portion of the title of the
document.

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [x] Title and Author MetaTags have been inserted into the document 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [x] Final pass/approval (Final Review)

