### PR TITLE
Fixes for incorrect markdown heading levels in multiple documents

### DIFF
--- a/docs/guides/apache-sites-enabled.md
+++ b/docs/guides/apache-sites-enabled.md
@@ -1,12 +1,13 @@
 # Apache Web Server Multi-Site Setup
 
 ## What You Need
+
 * A server running Rocky Linux
 * Knowledge of the command-line and text editors (This example uses *vi*, but can be adapted to your favorite editor.)
     * If you'd like to learn about the vi text editor, [here's a handy tutorial](https://www.tutorialspoint.com/unix/unix-vi-editor.htm).
 * Basic knowledge about installing and running web services
 
-# Apache Web Server Multi-Site Setup
+## Introduction
 
 Rocky Linux has many ways for you to set up a web site. This is just one method, using Apache, and is designed for use as a multi-site setup on a single server. While this method is designed for multi-site servers, it can also act as a base configuration for a single site server as well. 
 
@@ -211,4 +212,3 @@ That's by design, so that we can easily remove things in the event that httpd fa
 This will create the link to the configuration file in *sites-enabled*, just like we want.
 
 Now just start httpd with `systemctl start httpd`. Or restart it if it’s already running: `systemctl restart httpd`, and assuming the web service restarts, you can now go and do some testing on your new site.
-

--- a/docs/guides/apache_hardened_webserver/index.md
+++ b/docs/guides/apache_hardened_webserver/index.md
@@ -1,17 +1,17 @@
-# Introduction
+# Apache Hardened Webserver
 
-## Prerequisites And Assumptions
+## Prerequisites and Assumptions
 
-* A Rocky Linux Web Server running Apache
+* A Rocky Linux web server running Apache
 * A heavy comfort level with issuing commands from the command-line, viewing logs, and other general systems administrator duties
-* A comfort level with a command line editor (our examples use _vi_, but you can substitute in your favorite editor)
-* Assumes an _iptables_ firewall, rather than _firewalld_ or hardware firewall.
-* Assumes the use of a hardware firewall that our trusted devices will sit behind.
+* A comfort level with a command line editor (our examples use _vi_ which will usually invoke the _vim_ editor, but you can substitute your favorite editor)
+* Assumes an _iptables_ firewall, rather than _firewalld_ or a hardware firewall.
+* Assumes the use of a gateway hardware firewall that our trusted devices will sit behind.
 * Assumes a public IP address directly applied to the web server. We are substituting a private IP address for all of our examples.
 
-# Introduction
+## Introduction
 
-Whether you are hosting multiple web sites for customers or a single, very important, web site for your business, hardening your web server will give you peace of mind, at the expense of a little more up-front work for the administrator. 
+Whether you are hosting multiple websites for customers, or a single, very important, website for your business, hardening your web server will give you peace of mind, at the expense of a little more up-front work for the administrator. 
 
 With multiple web sites uploaded by your customers, you can pretty much be guaranteed that one of them will upload a Content Management System (CMS) with the possibility of vulnerabilities. Most customers are focused on ease of use, not security, and what happens is that updating their own CMS becomes a process that falls out of their priority list altogether. 
 
@@ -19,18 +19,18 @@ While notifying customers of vulnerabilities in their CMS may be possible for a 
 
 Web server hardening can take many forms, which may include any or all of the below tools, and possibly others not defined here. 
 
-You might elect to use a couple of these tools and not the others, so for clarity and readability this document is split out into separate documents for each tool. The exception will be the packet-based firewall (_iptables_) which will be included in this main document.
+You might elect to use a couple of these tools, and not the others, so for clarity and readability this document is split out into separate documents for each tool. The exception will be the packet-based firewall (_iptables_) which will be included in this main document.
 
-* A good packet filter firewall based on ports (iptables, firewalld, or hardware firewall - we will use _iptables_ for our example)[_iptables_ procedure](#iptablesstart)
+* A good packet filter firewall based on ports (iptables, firewalld, or hardware firewall - we will use _iptables_ for our example) [_iptables_ procedure](#iptablesstart)
 * A Host-based Intrusion Detection System (HIDS), in this case _ossec-hids_ [Apache Hardened Web Server - ossec-hids](ossec-hids.md)
 * A Web-based Application Firewall (WAF), with _mod\_security_ rules [Apache Hardened Web Server - mod_security](modsecurity.md)
 * Rootkit Hunter (rkhunter): A scan tool that checks against Linux malware [Apache Hardened Web Server - rkhunter](rkhunter.md)
-* Database security (we are using _mariadb-server_ here) [Database - mariadb-server](../database_mariadb-server.md)
+* Database security (we are using _mariadb-server_ here) [MariaDB Database Server](../database_mariadb-server.md)
 * A secure FTP or SFTP server (we are using _vsftpd_ here) [Secure FTP Server - vsftpd](../secure_ftp_server_vsftpd.md)
 
 This procedure does not replace the [Apache Web Server Multi-Site Setup](../apache-sites-enabled.md), it simply adds these security elements to it. If you haven't read it, take some time to look at it before proceeding.
 
-# Other Considerations
+## Other Considerations
 
 Some of the tools outlined here have both free and fee-based options. Depending on your needs or support requirements, you may want to consider the fee-based versions. You should research what is out there and make a decision after weighing all of your options. 
 
@@ -62,7 +62,7 @@ The diagram above shows our general layout. The _iptables_ packet-based firewall
 
 Each individual package section has the needed installation files and any configuration procedure listed. The installation instructions for _iptables_ is part of the [disable firewalld and enable the iptables services](../enabling_iptables_firewall.md) procedure.
 
-# <a name="iptablesstart"></a>Configuring iptables
+## <a name="iptablesstart"></a>Configuring iptables
 
 This portion of the documentation assumes that you have elected to install the _iptables_ services and utilities and that you are not planning on using _firewalld_. 
 
@@ -133,9 +133,9 @@ If we add new rules to the /etc/firewall.conf, just run it again to take those r
 
 You can always fix this however, from the console on the server. Because the _iptables_ service is enabled, a reboot will restore all rules that have been added with `/etc/firewall.conf`.
 
-# Conclusions
+## Conclusion
 
-There are a number of ways to harden an Apache web server to make it more secure. Each operates independently of the other options, so you can choose to install any or all of them based on your needs. 
+There are a number of ways to harden an Apache web server to make it more secure. Each operates independently of the other options, so you can choose to install any, or all, of them based on your needs. 
 
-Each requires some configuration with various tuning required for some to meet your specific needs. Since web services are constantly attacked by unscrupulous actors, implementing at least some of these will help an administrator sleep at night.
+Each requires some configuration with various tuning required for some to meet your specific needs. Since web services are constantly under attack 24/7 by unscrupulous actors, implementing at least some of these will help an administrator sleep at night.
 

--- a/docs/guides/apache_hardened_webserver/modsecurity.md
+++ b/docs/guides/apache_hardened_webserver/modsecurity.md
@@ -1,6 +1,6 @@
-# mod_security
+# Web-based Application Firewall (WAF)
 
-# Prerequisites
+## Prerequisites
 
 * A Rocky Linux Web Server running Apache
 * Proficiency with a command-line editor (we are using _vi_ in this example)
@@ -9,9 +9,9 @@
 * An account on Comodo's WAF site
 * All commands are run as the root user or sudo
 
-# Introduction
+## Introduction
 
-_mod\_security_ is an open-source web-based application firewall (WAF). It is just one possible component of a hardened Apache web server setup and can be used with or without other tools. 
+_mod\_security_ is an open-source web-based application firewall (WAF). It is just one possible component of a hardened Apache web server setup and can be used with, or without, other tools. 
 
 If you'd like to use this along with other tools for hardening, refer back to the [Apache Hardened Web Server guide](index.md). This document also uses all of the assumptions and conventions outlined in that original document, so it is a good idea to review it before continuing.
 
@@ -190,7 +190,7 @@ Now save your changes (with vi it's `SHIFT+:+wq!`) and restart httpd:
 
 If httpd starts OK, then you are ready to start using _mod\_security_ with the CWAF.
 
-# Conclusions
+## Conclusion
 
 _mod\_security_ with CWAF is another tool that can be used to help harden an Apache web server. Because CWAF's passwords require punctuation and because the standalone installation does not send that punctuation correctly, managing CWAF rules requires logging into the CWAF site and downloading rules and changes. 
 

--- a/docs/guides/apache_hardened_webserver/ossec-hids.md
+++ b/docs/guides/apache_hardened_webserver/ossec-hids.md
@@ -1,24 +1,23 @@
-# ossec-hids
+# Host-based Intrusion Detection System (HIDS)
 
-# Prerequisites
+## Prerequisites
 
 * Proficiency with a command-line text editor (we are using _vi_ in this example)
 * A heavy comfort level with issuing commands from the command-line, viewing logs, and other general systems administrator duties
 * An understanding that installing this tool also requires monitoring of actions and tuning to your environment
-* All commands are run as the root user or sudo
+* All commands are run as the root user or using sudo
 
-
-# Introduction
+## Introduction
 
 _ossec-hids_ is a host intrusion detection system that offers automatic action-response steps to help mitigate host intrusion attacks. It is just one possible component of a hardened Apache web server setup and can be used with or without other tools. 
 
-If you'd like to use this along with other tools for hardening, refer back to the [Apache Hardened Web Server routine](index.md). This document also uses all of the assumptions and conventions outlined in that original document, so it is a good idea to review it before continuing.
+If you'd like to use this along with other tools for hardening, refer back to the [Apache Hardened Web Server](index.md) document. This document also uses all of the assumptions and conventions outlined in that original document, so it is a good idea to review it before continuing.
 
 ## Installing Atomicorp's Repository
 
-To install _ossec-hids_, we need a third-party repository from Atomicorp. Atomicorp also offers a reasonably priced fee-based supported version for those who would like some human help if they run into trouble. 
+To install _ossec-hids_, we need a third-party repository from Atomicorp. Atomicorp also offers a reasonably priced fee-based supported version for those who would like professional support if they run into trouble. 
 
-If you'd prefer support and have the budget for it, check out [Atomicorp's non-free _ossec-hids_](https://atomicorp.com/atomic-enterprise-ossec/). Since we are going to need just a few packages from Atomicorp's free repository, we are going to modify the repository after we have it downloaded. 
+If you'd prefer support, and have the budget for it, check out [Atomicorp's paid _ossec-hids_](https://atomicorp.com/atomic-enterprise-ossec/) version. Since we are going to need just a few packages from Atomicorp's free repository, we are going to modify the repository after we have it downloaded. 
 
 Downloading the repository requires _wget_ so install that first if you don't have it. Install the EPEL repository as well if you do not have it installed already, with:
 
@@ -28,7 +27,7 @@ Now download and enable Atomicorp's free repository:
 
 `wget -q -O - http://www.atomicorp.com/installers/atomic | sh`
 
-This script will ask you to agree to the terms. Either type "yes" or hit 'Enter' to accept the "yes" as the default.
+This script will ask you to agree to the terms. Either type "yes" or hit 'Enter' to accept "yes" as the default.
 
 Next, it will ask you if you want to enable the repository by default, and again we want to accept the default or type "yes".
 
@@ -42,7 +41,7 @@ And then add this line beneath the "enabled = 1" in the top section:
 
 `includepkgs = ossec* inotify-tools`
 
-That's the only change we need, so save your changes and get out of the repository. (That'd be `Shift: wq!` in vi.)
+That's the only change we need, so save your changes and get out of the repository, (in vi that would be <kbd>esc</kbd> to enter command mode, then `: wq` to save and quit).
 
 This restricts the Atomicorp repository to only install and update these packages.
 
@@ -77,13 +76,13 @@ We will break apart this configuration showing the changes in line and explainin
 </global>
 ```
 
-By default, email notifications are turned off and the "\<global\>" configuration is basically empty. You want to turn on email notification and identify the people who should receive the email reports by email address. 
+By default, email notifications are turned off and the `<global>` configuration is basically empty. You want to turn on email notification and identify the people who should receive the email reports by email address. 
 
-The "\<smtp_server\>" section currently shows localhost, however you can specify an email server relay if you prefer, or simply setup the postfix email settings for the local host by following [this guide](../postfix_reporting.md). Y
+The `<smtp_server>` section currently shows localhost, however you can specify an email server relay if you prefer, or simply setup the postfix email settings for the local host by following [this guide](../postfix_reporting.md).
 
 ou need to set the "from" address, so that you can deal with SPAM filters on your email server which may see this email as SPAM. To avoid getting inundated with email, set the email reporting to 1 per hour. You can expand this or remark out this command if you like while you are getting started with _ossec-hids_ and need to see things quickly. 
 
-The "\<white_list\>" sections deal with the server's localohost IP and with the "public" address (remember, we are using a private address to demonstrate this) of the firewall, from which all connections on the trusted network will show. You can add multiple "\<white_list\>" entries as needed.
+The `<white_list>` sections deal with the server's localohost IP and with the "public" address (remember, we are using a private address to demonstrate this) of the firewall, from which all connections on the trusted network will show. You can add multiple `<white_list>` entries as needed.
 
 ```
 <syscheck>
@@ -93,11 +92,11 @@ The "\<white_list\>" sections deal with the server's localohost IP and with the 
 </syscheck>
 ```
 
-The "\<syscheck\>" section takes a look at a list of directories to include and exclude when looking for compromised files. Think of this as yet another tool for watching and protecting the file system against vulnerabilities. You should review the list of directories and see if there are others that you want to add in to the "\<syscheck\>" section. 
+The `<syscheck>` section takes a look at a list of directories to include and exclude when looking for compromised files. Think of this as yet another tool for watching and protecting the file system against vulnerabilities. You should review the list of directories and see if there are others that you want to add in to the `<syscheck>` section. 
 
-The "\<rootcheck\>" section just beneath the "\<syscheck\>" section is yet another protection layer. The locations that both "\<syscheck\>" and "\<rootcheck\>" watch are editable, but you probably will not need to make any changes to them.  
+The `<rootcheck>` section just beneath the `<syscheck>` section is yet another protection layer. The locations that both `<syscheck>` and `<rootcheck>` watch are editable, but you probably will not need to make any changes to them.  
 
-Changing the "\<frequency\>" for the "\<syscheck\>" run to once every 24 hours (86400 seconds) from the default of 22 hours is an optional change shown above.
+Changing the `<frequency>` for the `<rootcheck>` run to once every 24 hours (86400 seconds) from the default of 22 hours is an optional change shown above.
 
 ```
 <localfile>
@@ -110,7 +109,7 @@ Changing the "\<frequency\>" for the "\<syscheck\>" run to once every 24 hours (
 </localfile>
 ```
 
-The "\<localfile\>" section deals with the locations of the logs we want to watch. There are entries already in place for _syslog_ and _secure_ logs that you just need to verify the path to, but everything else can be left as is. 
+The `<localfile>` section deals with the locations of the logs we want to watch. There are entries already in place for _syslog_ and _secure_ logs that you just need to verify the path to, but everything else can be left as is. 
 
 We do need to add in the Apache log locations however, and we want to add these in as wild_cards, because we could have a bunch of logs for a lot of different web customers. That format is shown above.
 
@@ -129,7 +128,7 @@ We do need to add in the Apache log locations however, and we want to add these 
   </active-response>
 ```
 
-Finally, towards the end of the file we need to add the active response section. This section contains two parts, a "\<command\>" section, and the "\<active-response\>" section. 
+Finally, towards the end of the file we need to add the active response section. This section contains two parts, a `<command>` section, and the `<active-response>` section. 
 
 The "firewall-drop" script already exists within the ossec path.  It tells _ossec\_hids_ that if a level of 7 is reached, add a firewall rule to block the IP address for 20 minutes. Obviously, you can change the timeout value. Just remember that the configuration file times are all in seconds. 
 
@@ -143,10 +142,8 @@ And then:
 
 There are a lot of options for the _ossec-hids_ configuration file. You can find out about these options by visiting the [official documentation site](https://www.ossec.net/docs/).
 
-# Conclusions
+## Conclusion
 
 _ossec-hids_ is just one element of an Apache hardened web server. It can be used with other tools to gain better security for your web site. 
 
 While the installation and configuration are relatively straight forward, you will find that this is **not** an 'install it and forget it' application. You will need to tune it to your environment to gain the most security with the least amount of false-positive responses.
-
-

--- a/docs/guides/apache_hardened_webserver/rkhunter.md
+++ b/docs/guides/apache_hardened_webserver/rkhunter.md
@@ -1,6 +1,6 @@
-# rkhunter
+# Rootkit Hunter
 
-# Prerequisites
+## Prerequisites
 
 * A Rocky Linux Web Server running Apache
 * Proficiency with a command-line editor (we are using _vi_ in this example)
@@ -8,7 +8,7 @@
 * An understanding of what can trigger a response to changed files on the file system (such as package updates) is helpful
 * All commands are run as the root user or sudo
 
-# Introduction
+## Introduction
 
 _rkhunter_ (Root Kit Hunter) is a Unix-based tool that scans for rootkits, backdoors, and possible local exploits. It is a good part of a hardened web server, and is designed to notify the administrator quickly when something suspicious happens on the server's file system. 
 
@@ -58,6 +58,6 @@ To run _rkhunter_ manually:
 
 This will echo back to the screen as the checks are performed, prompting you to `[Press <ENTER> to continue]` after each section. 
 
-# Conclusions
+## Conclusion
 
 _rkhunter_ is one part of a hardened server strategy that can help in monitoring the file system and reporting any issues to the administrator. It is perhaps one of the easiest hardening tools to install, configure, and run.

--- a/docs/guides/database_mariadb-server.es.md
+++ b/docs/guides/database_mariadb-server.es.md
@@ -14,7 +14,7 @@ La combinación de _mariadb-server_ y su cliente _mariadb_ son una buena alterna
 
 _mariadb-server_ es bastante popular y es usado en muchos servidores, debido a que es requerido por el CMS de [Wordpress](https://es.wordpress.org/). Aunque el mismo también se puede usar para otras cosas.
 
-Si buscas aumentar aún más la seguridad por medio de otras herramientas, te aconsejo que leas la siguiente guía, [Apache Hardened Web Server guide](apache_hardened_webserver.md).
+Si buscas aumentar aún más la seguridad por medio de otras herramientas, te aconsejo que leas la siguiente guía, [Apache Hardened Web Server guide](apache_hardened_webserver/index.md).
 
 ### Instalando mariadb-server
 

--- a/docs/guides/database_mariadb-server.md
+++ b/docs/guides/database_mariadb-server.md
@@ -1,6 +1,6 @@
-# Database mariadb-server
+# MariaDB Database Server
 
-# Prerequisites
+## Prerequisites
 
 * A Rocky Linux server
 * Proficiency with a command-line editor (we are using _vi_ in this example)
@@ -8,7 +8,7 @@
 * An understanding of _mariadb-server_ databases is helpful
 * All commands are run as the root user or _sudo_
 
-# Introduction
+## Introduction
 
 The _mariadb-server_ and it's client _mariadb_ are the open source alternatives to _mysql-server_ and _mysql_, and they share command structure. _mariadb-server_ can be found running on many web servers, due to the popular [Wordpress CMS](https://wordpress.org/) which requires it. This database, though, has many other uses.
 
@@ -147,7 +147,7 @@ Thanks for using MariaDB!
 
 MariaDB should now be ready to use.
 
-# Conclusions
+## Conclusion
 
 A database server, such as _mariadb-server_, can be used for many purposes. Because of the popularity of the Wordpress CMS, it is often found on web servers. Before we run the database in production, however, it is a good idea to strengthen its security. 
 

--- a/docs/guides/postfix_reporting.md
+++ b/docs/guides/postfix_reporting.md
@@ -1,6 +1,6 @@
-# Using postfix For Server Process Reporting
+# Using Postfix For Server Process Reporting
 
-# Prerequisites
+## Prerequisites
 
 * Complete comfort operating from the command line on a Rocky Linux server
 * Familiarity with an editor of your choice (this document uses the _vi_ editor, but you can substitute in your favorite editor)
@@ -8,7 +8,7 @@
 * The ability to assign variables in a bash script
 * Knowledge of what the _tail_, _more_, _grep_, and _date_ commands do
 
-# Introduction
+## Introduction
 
 Many Rocky Linux server administrators write scripts to perform specific tasks, like backups or file synchronization, and many of these scripts generate logs that have useful and sometimes very important information. Just having the logs, though, is not enough. If a process fails and logs that failure, but the busy administrator does not review the log, then a catastrophe could be in the making. 
 
@@ -75,7 +75,7 @@ The "somehost.localdomain" shows us that we need to make some changes, so stop t
 
 `systemctl stop postfix`
 
-### Configuring Postfix
+## Configuring Postfix
 
 Since we aren't setting up a complete, fully functional mail server, the configuration options that we will be using are not as extensive. The first thing we need to do is to modify the _main.cf_ file (literally the main configuration file for postfix), so let's make a backup first:
 
@@ -123,7 +123,7 @@ Now we need to tell postfix to use all of our changes. This is done with the pos
 
 Now start postfix and test your email again using the same procedure as above. You should now see that all of the "localdomain" instances have been changed to your actual domain. 
 
-## The date Command And A Variable Called today
+### The date Command and a Variable Called today
 
 Not every application will use the same logging format for the date. This means that you may have to get creative with any script you write for reporting by date. 
 
@@ -232,6 +232,6 @@ Run the script again, and you should now have an email from the server with the 
 
 You can now use [a crontab](cron_jobs_howto.md) to schedule this to run at a specific time.
 
-# Conclusion
+## Conclusion
 
 Using postfix can help you keep track of process logs that you want to monitor. You can use it along with bash scripting to gain a firm grasp of your system processes and be informed if there is trouble.

--- a/docs/guides/secure_ftp_server_vsftpd.md
+++ b/docs/guides/secure_ftp_server_vsftpd.md
@@ -1,14 +1,13 @@
 # Secure FTP Server - vsftpd
 
-
-# Prerequisites
+## Prerequisites
 
 * Proficiency with a command-line editor (we are using _vi_ in this example)
 * A heavy comfort level with issuing commands from the command-line, viewing logs, and other general systems administrator duties
 * An understanding of PAM, as well as _openssl_ commands is helpful.
 * All commands are run as the root user or sudo
 
-# Introduction 
+## Introduction 
 
 _vsftpd_ is the  Very Secure FTP Daemon (FTP being the file transfer protocol). It has been available for many years now, and is actually the default FTP daemon in Rocky Linux, as well as many other Linux distributions. 
 
@@ -250,7 +249,7 @@ When you test with a virtual user to the server running _vsftpd_, you should get
 
 If you are unable to upload a file, then you may need to go back and make sure that each of the above steps is completed. For instance, it could be that the ownership permissions for the "local_root" have not been set to the "vsftpd" user and the "nogroup" group.
 
-# Conclusions
+## Conclusion
 
 _vsftpd_ is a popular and common ftp server and can be set up as a stand alone server, or as part of an [Apache Hardened Web Server](apache_hardened_webserver/index.md). If set up to use virtual users and a certificate, it is quite secure. 
 


### PR DESCRIPTION
Fixes for multiple documents (linked from apache_hardened_webserver/index.md) where the markdown heading levels had top level headings in the documents. This caused the Table of contents to be empty. No changes done otherwise to documents apart from few changes to index.md.

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

