### PR TITLE
Requested warning for the stenstorp repository

### DIFF
--- a/docs/guides/mate_installation.md
+++ b/docs/guides/mate_installation.md
@@ -23,6 +23,9 @@ Enable this repository by entering:
 
 `dnf copr enable stenstorp/MATE`
 
+!!! Warning
+    The `stenstorp` repository is known to work for installing `mate` and `lightdm` (below), but is not maintained by the Rocky Linux community. Use at your own risk!
+
 You will get a warning message about the repository, but go ahead and enable it by typing `Y` to allow.
 
 As noted from the link above, you also need the Powertools repository and the EPEL. Go ahead and enable those now:

--- a/docs/guides/xfce_installation.md
+++ b/docs/guides/xfce_installation.md
@@ -38,6 +38,9 @@ You also need the Powertools and lightdm repositories. Go ahead and enable those
 
 `dnf copr enable stenstorp/lightdm`
 
+!!! Warning
+    The `stentsorp` repository is known to work for installing `lightdm`, but is not maintained by the Rocky Linux community. Use at your own risk!
+
 Again, you will be presented with a warning message about the repository. Go ahead and answer `Y` to the prompt.
 
 ## Check The Available Environments and Tools in the Group


### PR DESCRIPTION
* Both the MATE and XFCE installation documents mention the use of the
"stenstorp" repository. We needed to just warn users that these are not
maintained by Rocky Linux and should be used at their own risk.

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

