### PR TITLE
Revert "Requested warning for the stenstorp repository"

### DIFF
--- a/docs/guides/mate_installation.md
+++ b/docs/guides/mate_installation.md
@@ -23,9 +23,6 @@ Enable this repository by entering:
 
 `dnf copr enable stenstorp/MATE`
 
-!!! Warning
-    The `stenstorp` repository is known to work for installing `mate` and `lightdm` (below), but is not maintained by the Rocky Linux community. Use at your own risk!
-
 You will get a warning message about the repository, but go ahead and enable it by typing `Y` to allow.
 
 As noted from the link above, you also need the Powertools repository and the EPEL. Go ahead and enable those now:

--- a/docs/guides/xfce_installation.md
+++ b/docs/guides/xfce_installation.md
@@ -38,9 +38,6 @@ You also need the Powertools and lightdm repositories. Go ahead and enable those
 
 `dnf copr enable stenstorp/lightdm`
 
-!!! Warning
-    The `stentsorp` repository is known to work for installing `lightdm`, but is not maintained by the Rocky Linux community. Use at your own risk!
-
 Again, you will be presented with a warning message about the repository. Go ahead and answer `Y` to the prompt.
 
 ## Check The Available Environments and Tools in the Group


### PR DESCRIPTION
Reverts rocky-linux/documentation#162 Needs some quick changes.