### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The order of these sections is very important but has not been finalized yet, so
 
 Start Here | Sourcing SRPM | Rebranding | Building | Signing | Deployment
 --- | --- | --- | --- | --- | ---
-[Setup Development Environment](guides/development/package_dev_start.md) | [Rebranding HowTo](guides/development/package_debranding.md) | [Signing HowTo](guides/development/package_signing.md) [Build Troubleshooting](guides/development/package_build_troubleshooting.md)
+[Setup Development Environment](guides/development/package_dev_start.md) | [Rebranding HowTo](guides/development/package_debranding.md) | [Signing HowTo](guides/development/package_signing.md) <br /> [Build Troubleshooting](guides/development/package_build_troubleshooting.md)
 
 
 ## Security


### PR DESCRIPTION
In the "Development and Packaging" section the links for 'Signing HowTo' and 'Build Troubleshooting' appear as if they are the same. 

Adding a line break to make it easier to distinguish that there is actually 2 links available.

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [x] Title and Author MetaTags have been inserted into the document 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

