### PR TITLE
rocky_to_wsl_howto.md get rid of dbus issue

### DIFF
--- a/docs/guides/rocky_to_wsl_howto.md
+++ b/docs/guides/rocky_to_wsl_howto.md
@@ -33,6 +33,8 @@ passwd
 sudo
 cracklib-dicts
 openssh-clients
+python3-dbus
+dbus-glib
 ```
 4. Edit the `rinse` config file at `/etc/rinse/rinse.conf` and add the following lines, which are the entry for RL mirrors. As of this writing, we have a direct download, but this will be changed to a mirror as soon as available.
 ```bash
@@ -67,8 +69,11 @@ $ sudo tar --numeric-owner -c -C ./rocky_rc . -f <path to new tar file>
 13. Open a PowerShell prompt (does not need to be admin), and create a folder to hold your new RL distro.
 14. Import the tar file with this command:
 ```PowerShell
-wsl --import rocky_rc <path to folder from step 13> <path to tar file>
+wsl --import rocky_rc <path to folder from step 9> <path to tar file>
 ```
+Note: Default location of WSL is `%LOCALAPPDATA%\Packages\` 
+`e.g. for Ubuntu - C:\Users\tahder\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhks2fndhsd\LocalState\rootfs\home\txunil\rocky_rc`
+
 15. In the PowerShell prompt, launch your new distro with:
 ```PowerShell
 wsl -d rocky_rc


### PR DESCRIPTION
Update the howto and give example of the where the WSL home drive location in the Windows; and added the packages python3-dbus & dbus-glib to remove the annoying displays of [: No module named 'dbus'].

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] 5th Pass (Include document in TOC)
- [x] Final pass/approval (Final Review)

