### PR TITLE
Fix bullet for Either/Or

### DIFF
--- a/docs/guides/import_rocky_to_wsl_howto.md
+++ b/docs/guides/import_rocky_to_wsl_howto.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 Either 
+
 * Linux PC running VirtualBox - VirtualBox will not run under windows 10 with WSL2, which is needed for later steps. You can also use a dual boot PC, or a live distribution, but make sure you have VirtualBox available.
 
 Or


### PR DESCRIPTION
The bullet under Either for Either/Or in the Prerequisites is missing a blank line, making the bullet render inline with "Either" instead of on a separate line as the bullet under "Or" does.  This simply fixes that formatting so both bullets are present.

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

