### PR TITLE
Corrected command to clone git repository

### DIFF
--- a/docs/guides/migrate2rocky.md
+++ b/docs/guides/migrate2rocky.md
@@ -62,7 +62,7 @@ dnf install -y git
 Then clone the rocky-tools repository with:
 
 ```
-https://github.com/rocky-linux/rocky-tools.git
+git clone https://github.com/rocky-linux/rocky-tools.git
 ```
 
 Note: this method will download all of the scripts and files in the rocky-tools repository. 


### PR DESCRIPTION
Using the existing documentation users would be faced with:

-bash: https://github.com/rocky-linux/rocky-tools.git: No such file or directory

When attempting to clone the rocket-tools repo.  This minor change corrects this.

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ?
This is an update to existing documentation
- [x] Is this a non-English contribution? 
No language change to existing documentation
- [x] Title and Author MetaTags have been inserted into the document
No additional metadata required
- [x] If applicable, steps and instructions have been tested to work on a real system
Was literally just following the guide when I spotted the error :)
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

