### PR TITLE
Incorrect enable as mentioned in apparently deleted PR 246

### DIFF
--- a/docs/guides/enabling_iptables_firewall.md
+++ b/docs/guides/enabling_iptables_firewall.md
@@ -34,7 +34,7 @@ This will install everything that is needed to run a straight _iptables_ rule se
 
 Now we need to enable the _iptables_ service to make sure that it starts on boot:
 
-`dnf enable iptables`
+`systemctl enable iptables`
 
 ## Conclusion
 


### PR DESCRIPTION
* fixed syntax of the command to enable iptables

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

