### PR TITLE
No need to install wget when we have curl.

### DIFF
--- a/docs/guides/migrate2rocky.md
+++ b/docs/guides/migrate2rocky.md
@@ -69,16 +69,12 @@ Note: this method will download all of the scripts and files in the rocky-tools 
 
 ### The easy-but-slightly-less-secure way
 
-Okay, this is not necessarily the best thing to do, security-wise. But, it is the easiest way to grab the script. First, make sure you have *wget* installed (you'll generally want it around anyway):
-
-```
-dnf install -y wget
-```
+Okay, this is not necessarily the best thing to do, security-wise. But, it is the easiest way to grab the script.
 
 Then, run this command to download the script into whatever directory you're using:
 
 ```
-wget https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh
+curl https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh -o migrate2rocky.sh
 ```
 
 That command will download the file straight to your server, and *only* the file you want. But again, there are security concerns that suggest this isn't necessarily the best practice, so keep that in mind.

--- a/docs/guides/migrate2rocky.md
+++ b/docs/guides/migrate2rocky.md
@@ -71,7 +71,7 @@ Note: this method will download all of the scripts and files in the rocky-tools 
 
 Okay, this is not necessarily the best thing to do, security-wise. But, it is the easiest way to grab the script.
 
-Then, run this command to download the script into whatever directory you're using:
+Run this command to download the script into whatever directory you're using:
 
 ```
 curl https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh -o migrate2rocky.sh


### PR DESCRIPTION
curl is installed by anaconda for every different type of install in EL8
including minimal, it should always be there.  We can use curl to download the
script instead of wget and then we don't have to recommend that people follow
an additional step of installing wget.

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

