### PR TITLE
Fix non-escapable characters

### DIFF
--- a/docs/gemstones/nmtui.md
+++ b/docs/gemstones/nmtui.md
@@ -1,7 +1,7 @@
 ---
 title: nmtui - Network Management Tool
 author : tianci li
-contributors: Steven Spencer
+contributors: Steven Spencer, Neil Hanlon
 update : 2021-10-23
 ---
 
@@ -30,11 +30,11 @@ You can use the <kbd>Tab</kbd> key or the <kbd>↑</kbd><kbd>↓</kbd><kbd>←</
 
 ###  DHCP IPv4
 
-For IPv4, if it is to obtain network information using DHCP way, you only need to select * IPv4 CONFIGURATION * back ** \ < Automatic \> ** , and then run your terminal under `systemctl restart NetworkManager.service` , large In most cases, it can take effect. In rare cases, you need to switch the network card to take effect. For example, this way- `nmcli connection down ens33` , `nmcli connection up ens33`
+For IPv4, if it is to obtain network information using DHCP way, you only need to select *IPv4 CONFIGURATION* back ** &lt;Automatic&gt; ** , and then run your terminal under `systemctl restart NetworkManager.service` , large In most cases, it can take effect. In rare cases, you need to switch the network card to take effect. For example, this way- `nmcli connection down ens33` , `nmcli connection up ens33`
 
 ### Manually fix network information
 
-If you want to manually fix all IPv4 network information, you need to select ** \< Manual \> ** after *IPv4 CONFIGURATION* and add it line by line. For example, I like this:
+If you want to manually fix all IPv4 network information, you need to select ** &lt;Manual&gt;  ** after *IPv4 CONFIGURATION* and add it line by line. For example, I like this:
 
 |Item|Value|
 |---|---|
@@ -42,7 +42,7 @@ If you want to manually fix all IPv4 network information, you need to select ** 
 |Gateway|192.168.100.1||
 |DNS servers|8.8.8.8|
 
-Then click \< OK \> , return to the terminal interface step by step, and execute `systemctl restart NetworkManager.service` . Similarly, in rare cases, the network card needs to be switched on and off to take effect.
+Then click \< OK \> , return to the terminal interface step by step, and execute `systemctl restart NetworkManager.service`. Similarly, in rare cases, the network card needs to be switched on and off to take effect.
 
 ## Change the way of configuration files
 

--- a/docs/gemstones/nmtui.zh.md
+++ b/docs/gemstones/nmtui.zh.md
@@ -1,7 +1,7 @@
 ---
 title: nmtui - 网络管理工具
 author: tianci li
-contributors: Steven Spencer
+contributors: Steven Spencer, Neil Hanlon
 update: 2021-10-23
 ---
 
@@ -30,11 +30,11 @@ shell > nmtui
 
 ### DHCP的IPv4
 
-针对IPv4，如果是使用DHCP的方式获取网络信息，则只需要选择 *IPv4 CONFIGURATION* 后面的 **\<Automatic\>**，然后在您的终端中运行下`systemctl restart NetworkManager.service`，大多数的情况下都能生效，极少数的情况下需要开关网卡才能生效，例如这样的方式——`nmcli connection down ens33`，`nmcli connection up ens33`
+针对IPv4，如果是使用DHCP的方式获取网络信息，则只需要选择 *IPv4 CONFIGURATION* 后面的 ** &lt;Automatic&gt; **，然后在您的终端中运行下`systemctl restart NetworkManager.service`，大多数的情况下都能生效，极少数的情况下需要开关网卡才能生效，例如这样的方式——`nmcli connection down ens33`，`nmcli connection up ens33`
 
 ### 手动固定网络信息
 
-如果要将所有IPv4的网络信息进行手动固定，需要选择 *IPv4 CONFIGURATION* 后面的 **\<Manual\>**，一行一行进行添加，例如我这样的：
+如果要将所有IPv4的网络信息进行手动固定，需要选择 *IPv4 CONFIGURATION* 后面的 **&lt;Manual&gt;**，一行一行进行添加，例如我这样的：
 
 |项|值|
 |---|---|


### PR DESCRIPTION
* Author wanted the `<Manual>` and `<Automatic>` to be shown in bold to
call attention to the items, since these are items within the `nmtui`
interface and not actual code. This can be done with formatting
suggested by Neil Hanlon: `**&lt;Manual&gt;** and `** &lt;Automatic&gt;
**`

## Author checklist (to be completed by original Author)
- [ ] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

