### PR TITLE
undo one change in PR 348

### DIFF
--- a/docs/labs/index.en.md
+++ b/docs/labs/index.en.md
@@ -4,6 +4,6 @@ title: Tutorial Labs
 
 # Rocky Linux Tutorial Labs
 
-What are **Labs** and how do they differ from longer-form documentation like **Books**? Well the **Labs** section is designed for step by step work through of processes that can further your understanding. They include exercises to test your knowledge. These are educational documents with an emphasis on "educational." They are designed to help you with your understanding of a particular subject and provide working knowledge at the same time. Whew! There's too much content, isn't it?
+What are **Labs** and how do they differ from longer-form documentation like **Books**? Well the **Labs** section is designed for step by step work through of processes that can further your understanding. They include exercises to test your knowledge. These are educational documents with an emphasis on "educational." They are designed to help you with your understanding of a particular subject and provide working knowledge at the same time. Whew! That is a lot, isn't it?
 
 Do you have experience in a subject that would translate into a lab? It would be great if there were any! We want you to be involved, which is no different from participating in Rocky Linux documents. Simply head over to the [Mattermost Documentation channel](https://chat.rockylinux.org/rocky-linux/channels/documentation), join the conversation, Let us know what you want to write, don't worry! We will help you.


### PR DESCRIPTION
* The first paragraph change was undone as in English, this does not
make sense. I believe that I let this go ahead and pass for the Chinese
version. While the goal is 1-to-1 translations, we need to make things
clear in all languages, which is why I allowed this on the Chinese
language version.

## Author checklist (to be completed by original Author)
- [x] Is this document a good fit for the Rocky project ?
- [ ] Is this a non-English contribution? 
- [ ] Title and Author MetaTags have been inserted into the document 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness


## Rocky Documentation checklist  (to be completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] 5th Pass (Include document in TOC)
- [ ] Final pass/approval (Final Review)

