### PR TITLE
Fix two minor errors causing warnings on load of mkdocs

### DIFF
--- a/docs/guides/virtualization/vbox-rocky.it.md
+++ b/docs/guides/virtualization/vbox-rocky.it.md
@@ -137,7 +137,7 @@ Ora che abbiamo preparato tutto per l'installazione, devi solo cliccare su "Star
 * Rete & Nome Host
 * Impostazioni dell'utente
 
-Se non sei sicuro di qualcuna di queste impostazioni, fai riferimento al documento [Installazione di Rocky](../installazione.md).
+Se non sei sicuro di qualcuna di queste impostazioni, fai riferimento al documento [Installazione di Rocky](../installation.md).
 
 Una volta terminata l'installazione, dovreste avere un'istanza di VirtualBox&reg; di Rocky Linux in esecuzione.
 

--- a/docs/guides/web/apache_hardened_webserver/ossec-hids.it.md
+++ b/docs/guides/web/apache_hardened_webserver/ossec-hids.it.md
@@ -13,7 +13,7 @@ title: Sistema Intrusion Detection System Host-based (HIDS) author: Steven Spenc
 
 ## Introduzione
 
-Se volete usare questo insieme ad altri strumenti per il rafforzamento, fate riferimento al documento [Apache Web Server Rinforzato](index. md). Il presente documento utilizza anche tutte le ipotesi e le convenzioni delineate in tale documento originale, quindi è una buona idea rivederlo prima di continuare.
+Se volete usare questo insieme ad altri strumenti per il rafforzamento, fate riferimento al documento [Apache Web Server Rinforzato](index.md). Il presente documento utilizza anche tutte le ipotesi e le convenzioni delineate in tale documento originale, quindi è una buona idea rivederlo prima di continuare.
 
 Per installare _ossec-hids_, abbiamo bisogno di un repository di terze parti da Atomicorp. Atomicorp offre anche una versione supportata a prezzi ragionevoli per coloro che desiderano un supporto professionale se si trovano in difficoltà.
 


### PR DESCRIPTION
* Italian file vbox-rocky.it.md had the link to installation.md
translated to instalazione.md, which is incorrect. The link doesn't
exist and has been fixed.
* Italian file ossec-hids.it.md had a space added to the index.md
("index. md") which needed to be removed.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [x] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

