### PR TITLE
Fix translated files with incorrect links

### DIFF
--- a/docs/guides/virtualization/vbox-rocky.it.md
+++ b/docs/guides/virtualization/vbox-rocky.it.md
@@ -137,7 +137,7 @@ Ora che abbiamo preparato tutto per l'installazione, devi solo cliccare su "Star
 * Rete & Nome Host
 * Impostazioni dell'utente
 
-Se non sei sicuro di qualcuna di queste impostazioni, fai riferimento al documento [Installazione di Rocky](../installazione.md).
+Se non sei sicuro di qualcuna di queste impostazioni, fai riferimento al documento [Installazione di Rocky](../installation.md).
 
 Una volta terminata l'installazione, dovreste avere un'istanza di VirtualBox&reg; di Rocky Linux in esecuzione.
 

--- a/docs/guides/web/apache_hardened_webserver/ossec-hids.it.md
+++ b/docs/guides/web/apache_hardened_webserver/ossec-hids.it.md
@@ -13,7 +13,7 @@ title: Sistema Intrusion Detection System Host-based (HIDS) author: Steven Spenc
 
 ## Introduzione
 
-Se volete usare questo insieme ad altri strumenti per il rafforzamento, fate riferimento al documento [Apache Web Server Rinforzato](index. md). Il presente documento utilizza anche tutte le ipotesi e le convenzioni delineate in tale documento originale, quindi è una buona idea rivederlo prima di continuare.
+Se volete usare questo insieme ad altri strumenti per il rafforzamento, fate riferimento al documento [Apache Web Server Rinforzato](index.md). Il presente documento utilizza anche tutte le ipotesi e le convenzioni delineate in tale documento originale, quindi è una buona idea rivederlo prima di continuare.
 
 Per installare _ossec-hids_, abbiamo bisogno di un repository di terze parti da Atomicorp. Atomicorp offre anche una versione supportata a prezzi ragionevoli per coloro che desiderano un supporto professionale se si trovano in difficoltà.
 


### PR DESCRIPTION
* these files were fixed before, but now the errors have re-appeared.
Does Crowdin see them as un-translated once the fixes are put in place?
Can't be sure.  If they re-appear again, I'll see if the Itallian
translator can fix them in Crowdin.
* fixed vbox-rocky.it.md link that was pointing to `../installazione.md`
and should have been `../installation.md`
* fixed ossed-hids.it.md issue with a space here `[Apache Web Server
Rinforzato](index. md) on tthe index.md... removed the space so that it
now reads: `[Apache Web Server Rinforzato](index.md)`

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

