### PR TITLE
fix gemstone link

### DIFF
--- a/docs/gemstones/markdown-demo.md
+++ b/docs/gemstones/markdown-demo.md
@@ -6,7 +6,7 @@ update: 21-March-2022
 ---
 
 # Overview
-This guide demos popular Markdown tags used on [https://docs.rockylinux.org](docs.rockylinux.org)
+This guide demos popular Markdown tags used on [https://docs.rockylinux.org](https://docs.rockylinux.org)
 
 ## The Demo
 
@@ -25,4 +25,3 @@ Everywhere that Mary went
 !!! TIP
 
     The lamb was sure to go.
-


### PR DESCRIPTION
* This warning was being reported in mkdocs: "WARNING  -  Documentation
file 'gemstones/markdown-demo.md' contains a link to
'gemstones/docs.rockylinux.org' which is not found in the documentation
files."

The issue was the link was defined as local to the gemstone folder
([https://docs.rockylinux.org](docs.rockylinux.org)), rather than as the
site link ([https://docs.rockylinux.org](https://docs.rockylinux.org))

This minor change fixes that issue.

#### Author checklist (Completed by original Author)
- [ ] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] Final pass/approval (Final Review)

