### PR TITLE
Correct sha256sum invocation

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -51,10 +51,10 @@ wget https://download.rockylinux.org/pub/rocky/8.5/isos/x86_64/CHECKSUM
 Use the `sha256sum` utility to verify the integrity of the ISO file against corruption and/or tampering.
 
 ```
-sha256sum -c CHECKSUM --ignore-missing  Rocky-8.5-x86_64-minimal.iso
+sha256sum -c CHECKSUM --ignore-missing
 ```
 
-The output should show:
+This will check the integrity of the ISO file downloaded previously, provided that it is in the same directory. The output should show:
 
 ```
 Rocky-8.5-x86_64-minimal.iso: OK


### PR DESCRIPTION
Invoking sha256sum with a checksum file specified in the command line does not need the name of the file to be provided as long as it is in the same directory with the file name as listed in the CHECKSUM file.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

