### PR TITLE
Force retranslation

### DIFF
--- a/docs/guides/backup/rsnapshot_backup.md
+++ b/docs/guides/backup/rsnapshot_backup.md
@@ -2,6 +2,7 @@
 title: Backup Solution - Rsnapshot
 author: Steven Spencer
 contributors: Ezequiel Bruni
+tested with: 8.5, 8.6
 tags:
   - backup
   - rsnapshot
@@ -332,6 +333,10 @@ And add this line:
 ## Reporting The Backup Status
 
 To make sure that everything is backing up according to plan, you might want to send the backup log files to your email. If your are running multiple machine backups using _rsnapshot_, each log file will have its own name, which you can then send to your email for review by [Using the postfix For Server Process Reporting](../email/postfix_reporting.md) procedure.
+
+## Restoring a Backup
+
+Restoring a backup, either a few files or a complete restore, involves copying the files you want from the directory with the date that you want to restore from back to your machine. Simple!
 
 ## Conclusions and Other Resources
 

--- a/docs/guides/cms/cloud_server_using_nextcloud.md
+++ b/docs/guides/cms/cloud_server_using_nextcloud.md
@@ -2,7 +2,7 @@
 title: Cloud Server Using Nextcloud
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5
+tested with: 8.5, 8.6
 tags:
   - cloud
   - nextcloud

--- a/docs/guides/cms/dokuwiki_server.md
+++ b/docs/guides/cms/dokuwiki_server.md
@@ -2,12 +2,12 @@
 title: DokuWiki
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5
+tested with: 8.5, 8.6
 tags:
   - wiki
   - documentation
 ---
-  
+
 # DokuWiki Server
 
 ## Prerequisites And Assumptions
@@ -201,7 +201,7 @@ Either should work if you set your hosts file as above. This will bring you to t
 * In the "once again" field, re-type that same password.
 * In the "Initial ACL Policy" drop down, choose the option that works best for your environment.
 * Choose the appropriate check box for the license you want to put your content under.
-* Leave checked or uncheck the "Once a month, send anonymous usage data to the DokuWiki developers" checkbox
+* Leave checked (or uncheck if you prefer) the "Once a month, send anonymous usage data to the DokuWiki developers" checkbox
 * Click the "Save" button
 
 Your wiki is now ready for you to add content.

--- a/docs/guides/containers/lxd_server.md
+++ b/docs/guides/containers/lxd_server.md
@@ -2,13 +2,14 @@
 title: LXD Server
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5
+tested with: 8.5, 8.6
 tags:
   - lxd
   - enterprise
 ---
 
 # Creating a full LXD Server
+
 ## Introduction
 
 LXD is best described on the [official website](https://linuxcontainers.org/lxd/introduction/), but think of it as a container system that provides the benefits of virtual servers in a container, or a container on steroids.


### PR DESCRIPTION
Issue: translator noticed some old translated files with bad meta at the
top of the file. This doesn't happen with "new" translations. This
commit is designed to force a retranslation of those files to see if
this fixes the meta.

* minor changes made to rsnapshot_backup, cloud_server_using_nextcloud,
dokuwiki_server, and lxd_server

There are more of these files out there, so if this fixes things, then
we will address the rest in succession.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

