### PR TITLE
Fix navigation error when languages are introduced

### DIFF
--- a/docs/release_notes/.pages
+++ b/docs/release_notes/.pages
@@ -1,6 +1,6 @@
 ---
 nav:
-    - Current: 8_6.md
+    - ... | 8_6*.md
     - ... | 8.5.md
     - ... | 8_4*.md
     - ... | 8-changelog*.md

--- a/docs/release_notes/8_6.md
+++ b/docs/release_notes/8_6.md
@@ -1,5 +1,5 @@
 ---
-title: Release 8.6
+title: Current Release 8.6
 tags:
   - 8.6
   - 8.6 release


### PR DESCRIPTION
* Italian translator pointed out that a 404 error was being generated on
the "Release Notes" when the Italian language was selected. This was due
to an error introduced by myself dealing with the naming of the 8.6 file
in the .pages file. It has been fixed. The naming is then brought into
the source file (English) by way of the "title:" meta.

#### Author checklist (Completed by original Author)
- [ ] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [ ] If applicable, steps and instructions have been tested to work on a real system
- [ ] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Check that document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Basic Editorial Review)
- [ ] 4th Pass (Detailed Editorial Review and Peer Review)
- [ ] Final pass/approval (Final Review)

