### PR TITLE
Fix extra word

### DIFF
--- a/docs/guides/file_sharing/sftp.md
+++ b/docs/guides/file_sharing/sftp.md
@@ -243,7 +243,7 @@ useradd -M -d /var/www/sub-domains/com.myfixedaxel/html -g apache -s /usr/sbin/n
 
 Let's break down those commands a bit:
 
-* The `-M` option says to *not* create create the standard home directory for the user.
+* The `-M` option says to *not* create the standard home directory for the user.
 * `-d` specifies that what comes after is the *actual* home directory.
 * `-g` says that the group that this user belongs to is `apache`.
 * `-s` says that the shell the user is assigned is `/usr/sbin/nologin`


### PR DESCRIPTION
* word duplicated in the section dealing with adding web users for SFTP:

-M option says to *not* create create the standard home directory...

changed to

-M option says to *not* create the standard home directory...

Continued to proofread before doing this commit. The rest seems to be
OK.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

