### PR TITLE
lsyncd_mkdocs requirements.txt requires newer Python

### DIFF
--- a/docs/guides/contribute/mkdocs_lsyncd.md
+++ b/docs/guides/contribute/mkdocs_lsyncd.md
@@ -2,7 +2,10 @@
 title: Local Documentation - LXD
 author: Steven Spencer
 contributors: Ezequiel Bruni
-update: 27-Feb-2022
+tested with: 8.5, 8.6
+tags:
+  - contribute
+  - local envirmonent lxd
 ---
 
 # Introduction
@@ -57,6 +60,17 @@ First, get into the container with:
 ```
 lxc exec mkdocs bash
 ```
+
+!!! important "Changes in requirements.txt for 8.x"
+
+    The current `requirements.txt` will require a newer version of Python than what is installed by default in Rocky Linux 8.5 or 8.6. To be able to install all the other dependencies, do the following: 
+
+    ```
+    sudo dnf module enable python38
+    sudo dnf install python38
+    ```
+
+    You can then skip installing `python3-pip` in the packages found below.
 
 We will need a few packages to accomplish what we need to do:
 


### PR DESCRIPTION
* When installing mkdocs in a Rocky Linux container (8.x), the
`requirements.txt` will not fully install dependencies without
installing a newer version of Python. Default is Python36, needed at
minimum Python38.
* procedure adds admonition to deal with the change

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

