### PR TITLE
Update tested documents and test `dokuwiki_server.md` in 9.0

### DIFF
--- a/docs/guides/cms/cloud_server_using_nextcloud.md
+++ b/docs/guides/cms/cloud_server_using_nextcloud.md
@@ -2,7 +2,7 @@
 title: Cloud Server Using Nextcloud
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5, 8.6
+tested with: 8.5, 8.6, 9.0
 tags:
   - cloud
   - nextcloud

--- a/docs/guides/web/apache-sites-enabled.md
+++ b/docs/guides/web/apache-sites-enabled.md
@@ -2,7 +2,7 @@
 title: Apache Multisite
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5
+tested with: 8.5, 8.6, 9.0
 tags:
   - web
   - apache


### PR DESCRIPTION
* Updated meta tags for `cloud_server_using_nextcloud.md` and
`apache-sites-enabled.md` to show that they have been tested with 9.0
* Ran through the steps of the `dokuwiki_server.md` on Rocky Linux 9.0
and made sure they worked plus:
  - updated the reference for PHP 8.0 with regard to 9.0
- added the missing "f" option to the `tar ztvf dokuwiki-stable.tgz`
line
- Rearranged the firewall section to include `firewalld` and to note
that the `iptables` procedure is deprecated as of Rocky Linux 9.0

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

