### PR TITLE
Attempt to test Pound on 9.0

### DIFF
--- a/docs/guides/proxies/pound.md
+++ b/docs/guides/proxies/pound.md
@@ -2,13 +2,17 @@
 title: Pound
 author: Steven Spencer
 contributors:
-tested with: 8.5
+tested with: 8.5, 8.6
 tags:
   - proxy
   - proxies
 ---
 
 # Pound Proxy Server
+
+!!! important "Pound Missing from EPEL-9"
+
+    As of this writing, Rocky Linux 9.0 cannot be installed from the EPEL repository. While there are sources out there for SRPM packages, we can't verify the integrity of these sources. For this reason, we do not recommend installing the Pound proxy server on Rocky Linux 9.0 at this time. This may change if the EPEL once again picks up Pound.  Use this procedure specifically for Rocky Linux 8.5 or 8.6.
 
 ## Introduction
 
@@ -37,13 +41,13 @@ The following are minimum requirements for using this procedure:
     If you don't have either of these servers installed, you can do so on a container environment (LXD or Docker) or on bare metal, and get them up and running. For this procedure, you merely need to install them with their respective packages, and enable and start the services. We won't be modifying them significantly in any way.
 
     ```
-    dnf -y install nginx && dnf enable --now nginx
+    dnf -y install nginx && systemctl enable --now nginx
     ```
 
     or
 
     ```
-    dnf -y install httpd && dnf enable --now httpd
+    dnf -y install httpd && systemctl enable --now httpd
     ```
 
 ## Conventions


### PR DESCRIPTION
* Pound proxy server not available in the EPEL for 9.0 and other sources
can't be confirmed as safe.  Added admonition at the top of the file to
use this procedure only for 8.5 or 8.6 for the time being.
* Fixed an error in the install lines for enabling the two web servers

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

