### PR TITLE
Minor document changes and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ReText is good, but if you feel like exploring your other options, there are a f
 * [Mark Text](https://marktext.app) - Free, cross-platform, and open source
 * [ghostwriter](https://wereturtle.github.io/ghostwriter/) - Free, Windows and Linux, open source
 * [Remarkable](https://remarkableapp.github.io) - Linux-only, open source
-* [Atom](https://atom.io) - Free, cross-platform and open source. Not _only_ a Markdown editor. Has integration with Git and GitHub built-in.
+* [NvChad](https://nvchad.github.io) for the `vi`/`vim` user and the `nvim` client. A lot of plugins are available to enhance the editor for markdown. See [this document](https://docs.rockylinux.org/guides/editors/nvchad/) for a nice set of installation instructions.
 * [VS Code](https://code.visualstudio.com/) - A partially open source project from none other than Microsoft; VS Code is a lightweight and powerful editor available for Windows, Linux and MacOS. To contribute to this document project, you should get the following extensions: Git Graph, HTML Preview, HTML Snippets, Markdown All in One, Markdown Preview Enhanced, Markdown Preview Mermaid Support, and any more that catch your fancy.
 
 ### Markdown Tutorial

--- a/docs/guides/backup/mirroring_lsyncd.md
+++ b/docs/guides/backup/mirroring_lsyncd.md
@@ -31,7 +31,7 @@ Even so, it's a program worth learning for any sysadmin.
 
 The best description of `lsyncd`, comes from its own man page. Slightly paraphrased, `lsyncd` is a light-weight live mirror solution that is comparatively easy to install. It doesn't require new filesystems or blockdevices, and does not hamper local filesystem performance. In short, it mirrors files.
 
-`lsyncd` watches a local directory trees event monitor interface (inotify). It aggregates and combines events for a few seconds, and then spawns one (or more) process(es) to synchronize the changes. By default this is `rsync`.
+`lsyncd` watches a local directory tree's event monitor interface (inotify). It aggregates and combines events for a few seconds, and then spawns one (or more) process(es) to synchronize the changes. By default this is `rsync`.
 
 For the purposes of this guide, we will call the system with the original files the "master", and the one that we are synchronizing to will be the "target". It is actually possible to completely mirror a server using `lsyncd` by very carefully specifying directories and files that you want to synchronize. It's pretty sweet!
 
@@ -75,7 +75,7 @@ We will need some dependencies: a few that are required by `lsyncd` itself, and 
     dnf config-manager --enable crb
     ```
 
-    Doing this in 9 before then next steps, will allow you to finish the build without backtracking.
+    Doing this in 9 before the next steps, will allow you to finish the build without backtracking.
 
 And here are the dependencies we need for `lsyncd` itself, and its build process:
 

--- a/docs/guides/containers/lxd_server.md
+++ b/docs/guides/containers/lxd_server.md
@@ -308,6 +308,10 @@ As with the other passwords, save this to a secure location.
 
 ### <a name="firewallsetup"></a>Firewall Set Up - iptables
 
+!!! note "A note regarding Rocky Linux 9.0"
+
+    Starting with Rocky Linux 9.0, `iptables` and all of the associated utilities are officially deprecated. This means that in future versions of the OS, perhaps as early as 9.1, they will disappear altogether. For this reason, you should skip down to the `firewalld` procedure below before continuing.
+
 Before continuing, you will want a firewall set up on your server. This example is using _iptables_ and [this procedure](../security/enabling_iptables_firewall.md) to disable _firewalld_. If you prefer to use _firewalld_, simply substitute in _firewalld_ rules using the instructions below this section.
 
 Create your firewall.conf script:


### PR DESCRIPTION
* Removed the Atom editor from the README.md because it is officially
deprecated by the dev.
* Added NvChad in its place
* fixed "trees" to "tree's" for posessive reference in line for
mirroring_lsyncd.md doc
* also fixed incorrect word in the admonition ("then" should have been
"the")
* Added an admonition to lxd_server.md dealing with the deprecaton of
`iptables`

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

