### PR TITLE
Fix single line code that should have been multiline

### DIFF
--- a/docs/guides/security/ssh_public_private_keys.md
+++ b/docs/guides/security/ssh_public_private_keys.md
@@ -100,5 +100,7 @@ Once you have verified that you can SSH in without a password, remove the id_rsa
 
 On each of your target machines, make sure that the following permissions are applied:
 
-`chmod 700 .ssh/`
-`chmod 600 .ssh/authorized_keys`
+```
+chmod 700 .ssh/
+chmod 600 .ssh/authorized_keys
+```


### PR DESCRIPTION
End commands were entered as single line code-blocks which causes them
to appear on the same line.  Fixed.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

