### PR TITLE
Added temporary admonition for ZFS inclusion for 9

### DIFF
--- a/docs/books/lxd_server/00-toc.md
+++ b/docs/books/lxd_server/00-toc.md
@@ -2,7 +2,7 @@
 title: LXD Server
 author: Steven Spencer
 contributors: Ezequiel Bruni
-tested with: 8.5, 8.6
+tested with: 8.5, 8.6, 9.0
 tags:
   - lxd
   - enterprise
@@ -12,7 +12,13 @@ tags:
 
 !!! note "A note about Rocky Linux 9.0"
 
-    This procedure works just fine for 9.0. The exception is the ZFS procedure, as the latest version supported in their repository is 8.6. This will probably change going forward, but for now, if you want to use ZFS storage pools, consider staying on Rocky Linux 8.6. The chapter dealing with ZFS has been marked as specific to 8.6.
+    Days after the research for implementing this procedure in Rocky Linux 9.0 was completed, and after the documents were rewritten, the repository for ZFS was released for 9. This means that there are some needed edits to this procedure. For now, just know if you want to use ZFS and Rocky Linux 9, you simply need to substute this URL for the ZFS repository:
+
+    ```
+    https://github.com/zfsonlinux/zfsonlinux.github.com/blob/master/epel/zfs-release-2-2.el9.noarch.rpm
+    ```
+
+    and then go ahead and follow the ZFS Setup. An edit of this procedure to take advantage of the changes will happen soon.
 
 ## Introduction
 


### PR DESCRIPTION
* After this procedure was tested in 9 and after the documents were
rewritten, the repository for ZFS for 9 was released. This changes the
procedure and will require some edits of certain sections. In the
meantime, the admonition in the main page for the book explains the
change.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

