### PR TITLE
MATE remove admonition at bottom

### DIFF
--- a/docs/guides/desktop/mate_installation.md
+++ b/docs/guides/desktop/mate_installation.md
@@ -88,7 +88,3 @@ Next, click on your user name on the screen, but before you enter your password 
 ## Conclusion
 
 Some people are not satisfied with the newer GNOME implementations or simply prefer the older MATE GNOME 2 look and feel. For those people, getting MATE installed in Rocky Linux will provide a nice, stable alternative.
-
-!!! attention
-
-    After further testing, the desktop selection does **NOT** stick, even though MATE remains selected. Attempts to login produce a return to the login screen. To login to a MATE session, you must select MATE again, even though it will already show as selected. This is why the warning exists at the top of this procedure. Please use this guide at your own risk. If you discover a workaround that will help other users continue to use MATE with Rocky Linux, please report your workaround.


### PR DESCRIPTION
* When testing previously, I was unable to get the user logged in a
second time without re-selecting MATE. This time around, I didn't get a
choice to select MATE, but it did work on repeat reboots and logins.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

