### PR TITLE
Title issue = bash string color

### DIFF
--- a/docs/gemstones/string_color.md
+++ b/docs/gemstones/string_color.md
@@ -1,5 +1,5 @@
 ---
-titie: About the color of the string
+title: bash - String Color
 author: tianci li
 contributors: Steven Spencer
 tested with: 8.6, 9.0


### PR DESCRIPTION
* First, Title wasn't quite right-simplified
* Second, meta was incorrect; "titie:" instead of "title:" which caused the title to show up only as "Introduction" (the H1 header).

At some point, will need to modify `.pages` file to fix alphabetization of the Gemstone listing. It is out of order, mainly because the titles don't line up with the file names.

#### Author checklist (Completed by original Author)
- [x] Contribution a good fit for the Rocky project? Title and Author MetaTags inserted ?
- [ ] Is this a non-English contribution? 
- [x] If applicable, steps and instructions have been tested to work on a real system
- [x] Did you perform an initial self-review to fix basic typos and grammatical correctness

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Check that document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Basic Editorial Review)
- [x] 4th Pass (Detailed Editorial Review and Peer Review)
- [x] Final pass/approval (Final Review)

