### PR TITLE
Gemstone Sort

### DIFF
--- a/docs/gemstones/.pages
+++ b/docs/gemstones/.pages
@@ -1,4 +1,18 @@
 ---
 nav:
     - ... | index*.md
+    - ... | bash_stub*.md
+    - ... | string_color*.md
+    - ... | docker*.md
+    - ... | htop*.md
+    - ... | https_rsa_keygen*.md
+    - ... | markdown-demo-v2*.md
+    - ... | mtr*.md
+    - ... | nmcli*.md
+    - ... | nmtui*.md
+    - ... | perl_search_replace*.md
+    - ... | sed_search_replace*.md
+    - ... | setup_local_repo*.md
+    - ... | systemd_service_for_python_script*.md
+    - ... | view_kernel_conf*.md
     - ...

--- a/docs/gemstones/docker.md
+++ b/docs/gemstones/docker.md
@@ -1,14 +1,17 @@
 ---
-title: Install Docker Engine
+title: Docker - Install Engine
 author: wale soyinka
 contributors:
 date: 2021-08-04
+tags:
+  - docker
 ---
 
+# Introduction
 
 The Docker Engine can be used running native Docker style container workloads on Rocky Linux servers. This is sometimes preferred to running the full Docker Desktop environment.
 
-# Add the docker repository
+## Add the docker repository
 
 Use the `dnf` utility to add the docker repository to your Rocky Linux server. Type:
 
@@ -16,7 +19,7 @@ Use the `dnf` utility to add the docker repository to your Rocky Linux server. T
 sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 ```
 
-# Install the needed packages
+## Install the needed packages
 
 Install the latest version of Docker Engine, containerd, and Docker Compose, by running:
 
@@ -24,7 +27,7 @@ Install the latest version of Docker Engine, containerd, and Docker Compose, by 
 sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
 
-# Start and enable the systemd docker service (dockerd)
+## Start and enable the systemd docker service (dockerd)
 
 Use the `systemctl` utility to configure the dockerd daemon to automatically startup with the next system reboot and simultaneously start it for the current session. Type:
 
@@ -33,7 +36,7 @@ sudo systemctl --now enable docker
 ```
 
 
-## Notes
+### Notes
 
 ```
 docker-ce               : This package provides the underlying technology for building and running docker containers (dockerd) 

--- a/docs/gemstones/htop.md
+++ b/docs/gemstones/htop.md
@@ -1,11 +1,16 @@
 ---
-title: htop-Process Management
+title: htop - Process Management
 author: tianci li
 contributors: Steven Spencer
 date : 2021-10-16
+tags:
+  - htop
+  - processes
 ---
 
-#  install `htop` 
+# htop - Process Management
+
+## install `htop` 
 Every system administrator likes to use some of the more commonly used commands. Today I recommend `htop` as an alternative to the `top` command. To use the `htop` command usually, you need to install it first.
 
 ``` bash
@@ -17,7 +22,7 @@ dnf makecache
 dnf -y install htop
 ```
 
-#  Use `htop`
+## Use `htop`
 You only need to type `htop` in the terminal, and the interactive interface is as follows:
 
 ```
@@ -31,7 +36,7 @@ PID   USER   PRI   NI   VIRT   RES   SHR   S   CPU%   MEM%   TIME+   Command(mer
 
 <kbd>F1</kbd>Help   <kbd>F2</kbd>Setup  <kbd>F3</kbd>Search <kbd>F4</kbd>Filter <kbd>F5</kbd>Tree   <kbd>F6</kbd>SortBy <kbd>F7</kbd>Nice   <kbd>F8</kbd>Nice+  <kbd>F9</kbd>Kill   <kbd>F10</kbd>Quit
 
-##  Top Description
+### Top Description
 
 * The top 0 and 1 indicate the number of your CPU cores, and the percentage indicates the occupancy rate of a single core (of course, the total occupancy rate of the CPU can also be displayed)
     * The different colors of the progress bar indicate the percentage of different process types:
@@ -58,7 +63,7 @@ PID   USER   PRI   NI   VIRT   RES   SHR   S   CPU%   MEM%   TIME+   Command(mer
 * Load average, the three values ​​respectively represent the average load of the system in the last 1 minute, the last 5 minutes, and the last 15 minutes
 * Uptime, which means the running time after booting
 
-##  Process information description
+### Process information description
 
 * **PID-Process ID number**
 
@@ -78,13 +83,13 @@ PID   USER   PRI   NI   VIRT   RES   SHR   S   CPU%   MEM%   TIME+   Command(mer
 * TIME+-shows the running time since the process was started
 * Command-the command corresponding to the process
 
-##  Shortcut key description
+### Shortcut key description
 In the interactive interface, press the <kbd>F1</kbd> button to see the corresponding shortcut key description.
 
 * The up, down, left, and right direction keys can scroll through the interactive interface, and <kbd>space</kbd> can mark the corresponding process, which is marked in yellow.
 * The <kbd>N</kbd> button, the <kbd>P</kbd> button, the <kbd>M</kbd> button and the <kbd>T</kbd> button are respectively PID, CPU%, MEM%, TIME+ is used for sorting. Of course, you can also use the mouse to click to sort in ascending or descending order of a certain field.
 
-##  Other commonly used
+### Other commonly used
 To manage the process, use the <kbd>F9</kbd> button to send different signals to the process. The list of signals can be found in `kill -l`. The more commonly used ones are:
 
 | Signal | Description |
@@ -93,5 +98,5 @@ To manage the process, use the <kbd>F9</kbd> button to send different signals to
 |9 | Used to immediately end the running of the program, used to forcibly terminate the process, similar to the forced end in the windows taskbar |
 |15 | The default signal for the kill command. Sometimes if a problem has occurred in the process and the process cannot be terminated normally with this signal, we will try signal 9 |
 
-##  End
+## End
 `htop` is much easier to use than the `top` that comes with the system, it is more intuitive, and it improves daily use greatly. This is why usually the first thing after installing the operating system the author installs it.

--- a/docs/gemstones/markdown-demo-v2.md
+++ b/docs/gemstones/markdown-demo-v2.md
@@ -1,5 +1,5 @@
 ---
-title: Simple Markdown Demo 2
+title: Markdown Demo
 author: Einstein
 contributors: Dr. Ben Dover, Sweet Gypsy Rose
 tested with: 8.5

--- a/docs/gemstones/nmcli.md
+++ b/docs/gemstones/nmcli.md
@@ -1,6 +1,8 @@
 ---
-title: nmcli - set connection autoconnect 
+title: nmcli - Set Connection Autoconnect
 author: wale soyinka
+tags:
+  - nmcli
 ---
 
 # Modify NetworkManager connection profile autoconnect property

--- a/docs/gemstones/perl_search_replace.md
+++ b/docs/gemstones/perl_search_replace.md
@@ -1,6 +1,9 @@
 ---
-title: Perl - Search and Replace
+title: perl - Search and Replace
 author: Steven Spencer
+tags:
+  - perl
+  - search
 ---
 
 # `perl` Search and Replace


### PR DESCRIPTION
The "Gemstones" section had gotten long enough that the automatic sort wasn't properly taking care of the left-hand TOC. This was due to the file names not necessarily corresponding to the title of the document:

* modified the `.pages` file to properly sort the titles
* changed some titles so that the primary subject was listed first in the title
* fixed capitalization inconsistencies and spacing inconsistencies in the titles
* fixed a couple of files that had more than one H1 (#) header

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

