### PR TITLE
Remove leftovers in the LXD book

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ While you can create documentation in **any format** (seriously, we will accept 
 
 As we've said already, the best way to create Markdown files, particularly if you've not done it before, is to grab an editor for the operating system that you use on your PC or Laptop. A simple web search for "Markdown editors" will show you a bunch to choose from.
 
-Pick one to use that is compatible with your Operating System [ReText](https://github.com/retext-project/retext), a cross-platform Markdown editor, was used to create this document. Again, if you prefer to create your Markdown files in your text editor that you are already familiar with, that is just fine.
+Pick one to use that is compatible with your Operating System. [ReText](https://github.com/retext-project/retext), a cross-platform Markdown editor, was used to create this document. Again, if you prefer to create your Markdown files in your text editor that you are already familiar with, that is just fine.
 
 #### Alternate Markdown Editors
 

--- a/docs/books/lxd_server/03-lxdinit.md
+++ b/docs/books/lxd_server/03-lxdinit.md
@@ -90,12 +90,6 @@ Would you like stale cached images to be updated automatically? (yes/no) [defaul
 Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:
 ```
 
-Trust password for new clients:
-Again:
-```
-
-This trust password is how you will connect to the snapshot server or back from the snapshot server, so set this with something that makes sense in your environment. Save this entry to a secure location, such as a password manager.
-
 ## Setting Up User Privileges
 
 Before we continue on, we need to create our "lxdadmin" user and make sure that it has the privileges it needs. We need the "lxdadmin" user to be able to _sudo_ to root and we need it to be a member of the lxd group. To add the user and make sure it is a member of both groups do:


### PR DESCRIPTION
This pull request removes some left-over text in the LXD book, which breaks formatting on the web page and confuses the reader. I've also added a missing dot on the landing README.md - a minor change that does not warrant a separate request.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

