### PR TITLE
Remove reference to minor versions in LXD ZFS documentation

### DIFF
--- a/docs/books/lxd_server/01-install.md
+++ b/docs/books/lxd_server/01-install.md
@@ -29,7 +29,7 @@ dnf upgrade
 
 If there were any kernel updates during the upgrade process, reboot the server.
 
-### OpenZFS Repository for 8.6 and 9.0
+### OpenZFS Repository for 8 and 9
 
 Install the OpenZFS repository with:
 


### PR DESCRIPTION
The ZFS release package given uses $releasever, is not specific to 8.6 and 9.0, and with releasever=8 will at time of writing use the 8.7 repo.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

