### PR TITLE
# address issue #992

### DIFF
--- a/docs/books/lxd_server/01-install.md
+++ b/docs/books/lxd_server/01-install.md
@@ -37,12 +37,6 @@ Install the OpenZFS repository with:
 dnf install https://zfsonlinux.org/epel/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
 ```
 
-We also need the GPG key, so use this command to get that:
-
-```
-gpg --import --import-options show-only /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
-```
-
 ## Install snapd, dkms, vim, and kernel-devel
 
 LXD must be installed from a snap for Rocky Linux. For this reason, we need to install `snapd` (and a few other useful programs) with:


### PR DESCRIPTION
* zfs import key location is both incorrect, and when used with the correct link, does not properly import the key. Key is imported when zfs is installed with a key verification prompt.
* remove key import procedure

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

