### PR TITLE
Update php.md

### DIFF
--- a/docs/guides/web/php.md
+++ b/docs/guides/web/php.md
@@ -413,7 +413,6 @@ pm.max_children = 50
 pm.start_servers = 12
 pm.min_spare_servers = 12
 pm.max_spare_servers = 36
-pm.process_idle_timeout = 10s
 pm.max_requests = 500
 ```
 


### PR DESCRIPTION
Line 416 remove 
"pm.process_idle_timeout = 10s"

This setting only works with Ondemand
https://www.php.net/manual/en/install.fpm.configuration.php pm.process_idle_timeout
The number of seconds after which an idle process will be killed. Used only when pm is set to ondemand. Available units: s(econds)(default), m(inutes), h(ours), or d(ays). Default value: 10s.

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

