### PR TITLE
Update development tools group install for Rocky 9

### DIFF
--- a/docs/guides/custom-linux-kernel.md
+++ b/docs/guides/custom-linux-kernel.md
@@ -60,6 +60,12 @@ A common source of failure encountered during the kernel build process may be ca
     ```
     > sudo dnf -y groupinstall 'C Development Tools and Libraries'
     ```
+    
+    if you get 'Module or Group 'C Development Tools and Libraries' is not available.' error the below command is equivalent to above
+    
+     ```
+    > sudo dnf -y groupinstall 'Development Tools'
+    ```
 
 2. Some other libraries, header files and applications that you might need can also be obtained by installing the following packages. Type:
 

--- a/docs/guides/custom-linux-kernel.md
+++ b/docs/guides/custom-linux-kernel.md
@@ -61,7 +61,7 @@ A common source of failure encountered during the kernel build process may be ca
     > sudo dnf -y groupinstall 'C Development Tools and Libraries'
     ```
     
-    if you get 'Module or Group 'C Development Tools and Libraries' is not available.' error the below command is equivalent to above
+    If you get 'Module or Group 'C Development Tools and Libraries' is not available.' error the below command is equivalent to above:
     
      ```
     > sudo dnf -y groupinstall 'Development Tools'


### PR DESCRIPTION
using     ``` > sudo dnf -y groupinstall 'C Development Tools and Libraries'``` on Rocky 9 does not work

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

