### PR TITLE
* Updated the tags in the meta and removed the update meta field, as …

### DIFF
--- a/docs/gemstones/RL9_network_manager.md
+++ b/docs/gemstones/RL9_network_manager.md
@@ -1,8 +1,10 @@
 ---
 title: RL9 - network manager 
 author : tianci li
-contributors: 
-update : 2023-01-06
+contributors: Steven Spencer 
+tags:
+  - networkmanager
+  - RL9
 ---
 
 # NetworkManager Network configuration tool suite
@@ -48,13 +50,13 @@ ens160.nmconnection
 ```
 
 The `ens160` here refers to the name of the network card in the system. You may wonder why the name looks so strange?
-The `udev` device manager , it supports many different naming schemes. By default, fixed names are assigned according to firmware, topology, and location information. Its advantages include:
+This is because of the `udev` device manager. It supports many different naming schemes. By default, fixed names are assigned according to firmware, topology, and location information. Its advantages include:
 
 * Device names are fully predictable.
 * Device names stay fixed even if you add or remove hardware, because no re-enumeration takes place.
 * Defective hardware can be seamlessly replaced.
 
-In RHEL 9 and the corresponding community version operating system, consistent device naming is enabled by default (disabling is not supported). The `udev` device manager will generate device names according to the following scheme:
+In RHEL 9 and the corresponding community version operating systems, consistent device naming is enabled by default (disabling is not supported). The `udev` device manager will generate device names according to the following scheme:
 
 | Scheme  | Description | Example     |
 |---------|-------------|-------------|

--- a/docs/gemstones/RL9_network_manager.md
+++ b/docs/gemstones/RL9_network_manager.md
@@ -1,0 +1,207 @@
+---
+title: RL9 - network manager 
+author : tianci li
+contributors: 
+update : 2023-01-06
+---
+
+# NetworkManager Network configuration tool suite
+
+In 2004, Red Hat launched the **NetworkManager** project, which aims to make it easier for Linux users to meet the needs of current network management, especially the management of wireless networks. Today, the project is managed by GNOME. The homepage of the website is: https://networkmanager.dev/
+
+Official introduction - NetworkManager is a standard Linux network configuration tool suite. It supports various network settings from desktop to server and mobile devices, and is perfectly integrated with popular desktop environments and server configuration management tools.
+
+The suite mainly includes two command line tools:
+
+* `nmtui`. Configure the network in a graphical interface.
+
+```bash
+shell > dnf -y install NetworkManager NetworkManager-tui
+shell > nmtui
+```
+
+|NetworkManager TUI||
+|---|---|
+|Edit a connection||
+|Activate a connection||
+|Set system hostname||
+|Quit||
+||\<OK\>|
+
+* `nmcli`. Use the command line to configure the network, either a pure command line or an interactive command line.
+
+```bash
+Shell > nmcli connection show                                                                                                        
+NAME    UUID                                  TYPE      DEVICE                                                                              
+color=green>ens160  25106d13-ba04-37a8-8eb9-64daa05168c9  ethernet  ens160
+```
+
+For RockyLinux 8.x, we introduced how to configure its network [here](./nmtui.md). You can use `vim` to edit the network card configuration file in the **/etc/sysconfig/network-script/** directory, or you can use `nmcli`/`nmtui`, both of which are acceptable.
+
+## Naming rules for udev device Manager
+
+For RockyLinux 9.x, if you go to the **/etc/sysconfig/network-scripts/** directory, there will be a **readme-ifcfg-rh.txt** description text that prompts you to go to the **/etc/NetworkManager/system-connections/** directory.
+
+```bash
+Shell > cd /etc/NetworkManager/system-connections/  && ls 
+ens160.nmconnection
+```
+
+The `ens160` here refers to the name of the network card in the system. You may wonder why the name looks so strange?
+The `udev` device manager , it supports many different naming schemes. By default, fixed names are assigned according to firmware, topology, and location information. Its advantages include:
+
+* Device names are fully predictable.
+* Device names stay fixed even if you add or remove hardware, because no re-enumeration takes place.
+* Defective hardware can be seamlessly replaced.
+
+In RHEL 9 and the corresponding community version operating system, consistent device naming is enabled by default (disabling is not supported). The `udev` device manager will generate device names according to the following scheme:
+
+| Scheme  | Description | Example     |
+|---------|-------------|-------------|
+| 1       | Device names incorporate firmware or BIOS-provided index numbers for onboard devices. If this information is not available or applicable, `udev` uses scheme 2. | eno1 |
+| 2       | Device names incorporate firmware or BIOS-provided PCI Express (PCIe) hot plug slot index numbers. If this information is not available or applicable, `udev` uses scheme 3. | ens1 |
+| 3       | Device names incorporate the physical location of the connector of the hardware. If this information is not available or applicable, `udev` uses scheme 5. | enp2s0 |
+| 4       | Device names incorporate the MAC address. Red Hat Enterprise Linux does not use this scheme by default, but administrators can optionally use it. | enx525400d5e0fb |
+| 5       | The traditional unpredictable kernel naming scheme. If `udev` cannot apply any of the other schemes, the device manager uses this scheme. | eth0 |
+
+`udev` device Manager names the prefix of the Nic based on the type of interface: 
+
+* **en** for Ethernet. 
+* **wl** for wireless LAN (WLAN). 
+* **ww** for wireless wide area network (WWAN). 
+* **ib**, InfiniBand network. 
+* **sl**, Serial Line Internet Protocol (slip)
+
+Add some suffixes to the prefix, such as:
+
+* **o<on-board_index_number>**
+* **s<hot_plug_slot_index_number>[f<function>][d<device_id>]**
+* **x<MAC_address>**
+* **[P<domain_number>]p<bus>s<slot>[f<function>][d<device_id>]**
+* **[P<domain_number>]p<bus>s<slot>[f<function>][u<usb_port>][…​][c<config>][i<interface>]**
+
+You can use `man 7 systemd.net-naming-scheme` to get more detailed information. 
+
+## `nmcli` command (recommended)
+
+Users can not only configure the network in a pure command line mode, but also use interactive commands to configure the network.
+
+### `nmcli connection`
+
+The `nmcli connection` command can show, delete, add, modify, edit, up, down, and so on.
+
+For specific usage, please refer to `nmcli connection add --help`, `nmcli connection edit --help`, `nmcli connection modify --help` and so on.
+
+For example, to configure a new ipv4 static ip connection using a pure command line and start up automatically, it can be:
+
+```bash
+Shell > nmcli  connection  add  type  ethernet  con-name   CONNECTION_NAME  ifname  NIC_DEVICE_NAME   \
+ipv4.method  manual  ipv4.address "192.168.10.5/24"  ipv4.gateway "192.168.10.1"  ipv4.dns "8.8.8.8,114.114.114.114" \
+ipv6.method  disabled  autoconnect yes
+```
+
+If you are using DHCP to get the ipv4 address, it can be:
+
+```
+Shell > nmcli  connection  add  type ethernet con-name CONNECTION_NAME  ifname  NIC_DEVICE_NAME \
+ipv4.method  auto  ipv6.method  disabled  autoconnect  yes
+```
+
+With the above configuration, the connection is not activated. You need to perform the following operations:
+
+```bash
+Shell > nmcli connection up  NIC_DEVICE_NAME
+```
+
+Enter the interactive interface through the `edit` keyword on the basis of the existing connection, and modify it:
+
+```bash
+Shell > nmcli connection  edit  CONNECTION_NAME
+nmcli > help
+```
+
+You can also modify one or more properties of the connection directly from the command line with the `modify` keyword. For example:
+
+```bash
+Shell > nmcli connection modify CONNECTION_NAME autoconnect yes ipv6.method dhcp
+```
+
+!!! info
+
+    Operations through `nmcli` or `nmtui` are saved permanently, not temporarily.
+
+#### Link aggregation
+
+Some use multiple network cards for link aggregation. In the early days, using **bonding** technology, there were seven working modes (0~6), and the bond mode only supported two network cards at most; Later, the **teming** technology is gradually used as an alternative, there are five working modes, and the team mode can use up to eight network cards. Comparison link between bonding and teming——https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-comparison_of_network_teaming_to_bonding
+
+For example, the 0 mode of bonding:
+
+```bash
+Shell > nmcli  connection  add  type  bond  con-name  BOND_CONNECTION_NAME   ifname  BOND_NIC_DEVICE_NAME  mode 0  
+Shell > nmcli  connection  add  type  bond-slave   ifname NIC_DEVICE_NAME1   masster  BOND_NIC_DEVICE_NAME
+Shell > nmcli  connection  add  type  bond-slave   ifname NIC_DEVICE_NAME2   masster  BOND_NIC_DEVICE_NAME
+```
+
+## Configuration file of the network card (it is not recommended to modify it by means of vim, etc.)
+
+You can view more detailed information through `man 5 NetworkManager.conf` and `man 5 nm-settings-nmcli`.
+
+For example, the content of the file is an ini style key file:
+
+```bash
+Shell > cat /etc/NetworkManager/system-connections/ens160.nmconnection                                                               
+[connection]                                                                                                                                
+id=ens160                                                                                                                                   
+uuid=5903ac99-e03f-46a8-8806-0a7a8424497e                                                                                                   
+type=ethernet                                                                                                                               
+interface-name=ens160                                                                                                                       
+timestamp=1670056998                                                                                                                        
+                                                                                                                                            
+[ethernet]                                                                                                                                  
+mac-address=00:0C:29:47:68:D0                                                                                                               
+                                                                                                                                            
+[ipv4]                                                                                                                                      
+address1=192.168.100.4/24,192.168.100.1                                                                                                     
+dns=8.8.8.8;114.114.114.114;                                                                                                                
+method=manual                                                                                                                               
+                                                                                                                                            
+[ipv6]                                                                                                                                      
+addr-gen-mode=default                                                                                                                       
+method=disabled                                                                                                                             
+                                                                                                                                            
+[proxy] 
+```
+
+* Lines that start with # and blank lines are considered comments;
+* Enclosed in [ and ] is the section it intends to declare the title, and below it are the specific key-value pairs contained. Each declared title and its key-value pair form a syntax segment;
+* Any file with the .nmconnection suffix can be used by **NetworkManager**.
+
+**connection** title names can contain these common key-value pairs:
+
+| key name       | description |
+|----------------|-------------|
+| id             | sThe alias of con-name, whose value is a string.|
+| uuid           | Universal unique identifier, whose value is a string. |
+| type           | The type of connection, whose values can be ethernet, bluetooth, vpn, vlan, and so on. You can use `man  nmcli` to view all supported types. |
+| interface-name | Network card device name. |
+| timestamp      | Unix timestamp, in seconds. The value here is the number of seconds since January 1, 1970.|
+| autoconnect    | Whether it starts automatically when the system starts. The value is of Boolean type.|
+
+**ethernet** title names can contain these common key-value pairs:
+
+| key name       | description |
+|----------------|-----|
+| mac-address    | MAC physical address. |
+| mtu            | Maximum Transmission Unit.|
+| auto-negotiate | Whether to negotiate automatically. The value is Boolean type.|
+| duplex         | The Values can be half (half-duplex), full (full-duplex) |
+| speed          | Specify the transmission rate of the network card. 100 is 100Mbit/s. If **auto-negotiate=false**, the **speed** key and **duplex** key must be set; if **auto-negotiate=true**, the speed used is the negotiated speed, and the writing here does not take effect (this is only applicable to the BASE-T 802.3 specification); when nonzero, the **duplex** key must have a value.|
+
+**ipv4** title names can contain these common key-value pairs:
+
+| key name       | description |
+|----------------|-----|
+| addresses | |
+| gateway | |
+| dns |  |
+| method | The method to be obtained by ip. The value is of string type. The value can be: auto, disabled, link-local, manual, shared |


### PR DESCRIPTION
…this is handled by default now.

* slight wording change and the move of a comma over one space
* In the line "RHEL 9 and the corresponding community version operating system" to "...operating systems" as this indicates Rocky, Alma, Oracle, etc. (multiple community versions)

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

