### PR TITLE
Recent discovery fix

### DIFF
--- a/docs/books/lxd_server/01-install.md
+++ b/docs/books/lxd_server/01-install.md
@@ -112,6 +112,10 @@ To make these kernel changes, we are going to create a file called _90-lxd-overr
 vi /etc/sysctl.d/90-lxd-override.conf
 ```
 
+!!! warning "RL 9 and MAX value of `net.core.bpf_jit_limit`
+
+    Because of recent kernel security updates, the max value of `net.core.bpf_jit_limit` appears to be 1000000000. Please adjust this value in the self-documenting file below if you are running Rocky Linux 9.x. If you set it above this limit **OR** if you fail to set it at all, it will default to the system default of 264241152, which may not be enough if you run a large number of containers.
+
 Place the following content in that file. Note that if you are wondering what we are doing here, the file content below is self-documenting:
 
 ```
@@ -150,7 +154,7 @@ ded if not using IPv6, but...
 
 net.ipv6.neigh.default.gc_thresh3 = 8192
 
-# This is a limit on the size of eBPF JIT allocations which is usually set to PAGE_SIZE * 40000.
+# This is a limit on the size of eBPF JIT allocations which is usually set to PAGE_SIZE * 40000. Set this to 1000000000 if you are running Rocky Linux 9.x
 
 net.core.bpf_jit_limit = 3000000000
 


### PR DESCRIPTION
* on RL 9, `net.core.bpf_jit_limit` can't be set above 1000000000
* attempting to set it above this value will cause the default to be set (264241152) which may not be enough for a large number of containers
* added an admonition to caution on this and also a documentation note within the sysctl values file.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

