### PR TITLE
# Translation and display issues

### DIFF
--- a/docs/gemstones/RL9_network_manager.md
+++ b/docs/gemstones/RL9_network_manager.md
@@ -28,7 +28,7 @@ shell > nmtui
 |Activate a connection||
 |Set system hostname||
 |Quit||
-||\<OK\>|
+||OK|
 
 * `nmcli`. Use the command line to configure the network, either a pure command line or an interactive command line.
 
@@ -76,11 +76,11 @@ In RHEL 9 and the corresponding community version operating systems, consistent 
 
 Add some suffixes to the prefix, such as:
 
-* **o<on-board_index_number>**
-* **s<hot_plug_slot_index_number>[f<function>][d<device_id>]**
-* **x<MAC_address>**
-* **[P<domain_number>]p<bus>s<slot>[f<function>][d<device_id>]**
-* **[P<domain_number>]p<bus>s<slot>[f<function>][u<usb_port>][…​][c<config>][i<interface>]**
+* **o** on-board_index_number
+* **s** hot_plug_slot_index_number **[f]** function **[d]** device_id
+* **x** MAC_address
+* **[P]** domain number **p** bus **s** slot **[f]** function **[d]** device_id
+* **[P]** domain number **p** buss **s** slot **[f]** function **[u]** usb port **[c]** config **[i]** interface
 
 You can use `man 7 systemd.net-naming-scheme` to get more detailed information. 
 


### PR DESCRIPTION
* items within the angle brackets do NOT show up in the document display
* in addition, these items play havoc with the translation formatting
* removed the <> items and insterted them as text qualifiers
* This required that the bold font also be adjusted for clarity
* viewed in local mkdocs and it appears to work find for display, so maybe it will work for the translation engine as well.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

