### PR TITLE
Two translation files have wrong link to 8_7.md

### DIFF
--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -18,7 +18,7 @@ Cette page d'accueil vous donnera une introduction au site de cette documentatio
 
 En ce moment, vous êtes sur la page d'accueil de la documentation. Si vous jetez un coup d'œil au menu supérieur (qui devrait être toujours disponible, y compris sur les appareils mobiles) vous pouvez voir la structure principale montrant les sections du niveau principal du site de documentation. Si vous cliquez sur chaque lien de menu en haut (essayez 'Guides' par exemple) puis sur le côté gauche vous verrez la liste des *sous-sections* pour chaque section principale. Les guides traitent de nombreux thèmes.
 
-Lorsque vous ouvrez un document, sur le côté droit vous verrez une 'Table des matières' avec des liens de navigation cliquables pour ce document (pour les appareils mobiles essayez de basculer l'affichage horizontalement). Pour les documents longs, comme les [Notes de publication](release_notes/8_7. md), la table des matières facilite la navigation dans le document. Si vous lisez un document long et que vous voulez revenir en haut de la page, appuyez sur <kbd>pg up</kbd> et vous verrez apparaître un bouton `Retour vers le haut` en haut de l'écran.
+Lorsque vous ouvrez un document, sur le côté droit vous verrez une 'Table des matières' avec des liens de navigation cliquables pour ce document (pour les appareils mobiles essayez de basculer l'affichage horizontalement). Pour les documents longs, comme les [Notes de publication](release_notes/8_7.md), la table des matières facilite la navigation dans le document. Si vous lisez un document long et que vous voulez revenir en haut de la page, appuyez sur <kbd>pg up</kbd> et vous verrez apparaître un bouton `Retour vers le haut` en haut de l'écran.
 
 Les sections principales du site de documentation sont :
 

--- a/docs/index.it.md
+++ b/docs/index.it.md
@@ -18,7 +18,7 @@ Questa pagina iniziale vi fornirà un'introduzione al sito web della documentazi
 
 In questo momento vi trovate nella pagina iniziale della documentazione. Se si dà un'occhiata al menu in alto (sempre disponibile, anche sui dispositivi mobili) si può vedere la struttura principale che mostra le sezioni di primo livello del sito della documentazione. Se si clicca su ogni voce del menu superiore (ad esempio, "Guide"), sul lato sinistro viene visualizzato l'elenco delle *sottosezioni* per ogni sezione principale. Le guide hanno molti argomenti di interesse.
 
-Quando si apre un documento, sulla destra viene visualizzata una 'Tabella dei contenuti' con collegamenti di navigazione cliccabili per quel documento (per i dispositivi mobili provare l'orientamento orizzontale). Per i documenti lunghi, come le [Note di rilascio](release_notes/8_7. md), l'indice facilita il salto all'interno del documento. Se si sta leggendo un documento lungo e si desidera tornare all'inizio, premere il tasto <kbd>pg su</kbd> e si vedrà apparire il pulsante `Torna all'inizio` nella parte superiore dello schermo.
+Quando si apre un documento, sulla destra viene visualizzata una 'Tabella dei contenuti' con collegamenti di navigazione cliccabili per quel documento (per i dispositivi mobili provare l'orientamento orizzontale). Per i documenti lunghi, come le [Note di rilascio](release_notes/8_7.md), l'indice facilita il salto all'interno del documento. Se si sta leggendo un documento lungo e si desidera tornare all'inizio, premere il tasto <kbd>pg su</kbd> e si vedrà apparire il pulsante `Torna all'inizio` nella parte superiore dello schermo.
 
 Le sezioni principali del sito di documentazione sono:
 


### PR DESCRIPTION
* Both index.fr.md and index.it.md in the docs dir had a space after the 8_7. which caused the server process to display them as non-existent files. This was correct.  The only way to fix this is manually outside of the translation engine.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

