### PR TITLE
Fix admonition types within files

### DIFF
--- a/docs/books/learning_bash/appendix/02-variables-logs.md
+++ b/docs/books/learning_bash/appendix/02-variables-logs.md
@@ -90,7 +90,7 @@ logfile=/var/log/dnf.log
 
 The `dnf.log` has a lot of information in it every day, so we are not posting that to the screen here, but you should see output that has only today's data in it. Give the script a try and if it works, then we can move on to the next step. After we've checked the output, the next step is that we want to do a pipe redirect to send the information to email.
 
-!!! hint
+!!! tip
 
     You need `mailx` and a mail daemon such as `postfix` installed to accomplish this next step. There's also some configuration that will *probably* be necessary for you to receive email from your server to your companies email address. Don't worry about those steps at this point, because you can check the `maillog` to see if the attempt was made and then work from there to get email from your server to your email address working. That's not something that this document is going to deal with. For now do:
 

--- a/docs/books/lxd_server/04-firewall.md
+++ b/docs/books/lxd_server/04-firewall.md
@@ -72,7 +72,7 @@ firewall-cmd --reload
 
 We want to allow all traffic from the bridge, so let's just add the interface, and then change the target from "default" to "ACCEPT" and we will be done:
 
-!!! attention
+!!! warning
 
     Changing the target of a firewalld zone *must* be done with the --permanent option, so we might as well just enter that flag in our other commands as well and forgo the --runtime-to-permanent option.
 

--- a/docs/books/lxd_server/08-snapshots.md
+++ b/docs/books/lxd_server/08-snapshots.md
@@ -82,7 +82,7 @@ Once you don't need a snapshot anymore, you can delete it:
 lxc delete ubuntu-test/ubuntu-test-1
 ```
 
-!!! important
+!!! warning
 
     You should always delete snapshots with the container running. Why? Well the _lxc delete_ command also works to delete the entire container. If we had accidentally hit enter after "ubuntu-test" in the command above, AND, if the container was stopped, the container would be deleted. No warning is given, it simply does what you ask.
 

--- a/docs/books/nvchad/custom/plugins/null_ls.md
+++ b/docs/books/nvchad/custom/plugins/null_ls.md
@@ -43,7 +43,7 @@ For proper operation, language servers must be installed separately with _Mason_
 
 The LSPs to be installed are `prettierd`, `markdownlint` and `stylua`. The first two LSPs will provide formatting and diagnostic capabilities for Markdown code, while the third provides support for formatting Lua code.
 
-!!! attention "Markdownlint setting"
+!!! warning "Markdownlint setting"
 
     For optimal use of the linter, a `rc` configuration file must be placed in your home directory; detailed instructions are available at the end of this document.
 

--- a/docs/books/nvchad/nerd_fonts.md
+++ b/docs/books/nvchad/nerd_fonts.md
@@ -29,7 +29,7 @@ https://www.nerdfonts.com/font-downloads
 
 The procedure for installing fonts on Rocky Linux is to save the fonts you want to add somewhere, and then install them with the `fc-cache` command. This procedure is not a true installation so much as a registration of the new fonts in the system.
 
-!!! important "Creation of compressed packages"
+!!! warning "Creation of compressed packages"
 
 	The procedure described below is not a standard procedure as each developer has packaged fonts using a custom scheme. So once downloaded and extracted, the contents must be checked to choose the procedure for copying the fonts.
 

--- a/docs/gemstones/view_kernel_conf.md
+++ b/docs/gemstones/view_kernel_conf.md
@@ -17,7 +17,7 @@ The Linux kernel stores running kernel information in two places via special fil
   - The older [procfs](https://man7.org/linux/man-pages/man5/procfs.5.html) which mounts `/proc` (verify via `mount -l -t proc`)
   - The newer [sysfs](https://man7.org/linux/man-pages/man5/sysfs.5.html) which mounts `/sys`    (verify via `mount -l -t sysfs`)
 
-!!! caution
+!!! warning
 
     Be cautious if examining the files mentioned here, altering them can change the behavior of the actual running kernel!
 

--- a/docs/guides/backup/mirroring_lsyncd.md
+++ b/docs/guides/backup/mirroring_lsyncd.md
@@ -67,7 +67,7 @@ We will need some dependencies: a few that are required by `lsyncd` itself, and 
 
 `dnf groupinstall 'Development Tools'`
 
-!!! important "For Rocky Linux 9.0"
+!!! warning "For Rocky Linux 9.0"
 
     `lsyncd` has been fully tested in Rocky Linux 9.0, and will work as expected. In order to get all of the needed dependencies installed, however, you will need to enable an additional repository:
 

--- a/docs/guides/backup/rsnapshot_backup.md
+++ b/docs/guides/backup/rsnapshot_backup.md
@@ -125,7 +125,7 @@ This documentation covers the installation of _rsnapshot_ on Rocky Linux only.
     ./autogen.sh
     ```
 
-    !!! hint
+    !!! tip
 
         You may get several lines that look like this:
 

--- a/docs/guides/backup/rsync_ssh.md
+++ b/docs/guides/backup/rsync_ssh.md
@@ -75,7 +75,7 @@ Now, scripting makes it super simple and safe so that you can test it fearlessly
 /usr/bin/rsync -ae ssh --delete root@source.domain.com:/home/your_user /home
 ```
 
-!!! attention
+!!! warning
 
     In this case, we assume that your home directory does not exist on the target machine. **If it exists, you may want to back it up before executing the script!**
 

--- a/docs/guides/cms/dokuwiki_server.md
+++ b/docs/guides/cms/dokuwiki_server.md
@@ -222,7 +222,7 @@ Instead of everyone having access to the wiki, we are going to assume that anyon
 
 #### `iptables` Firewall (deprecated)
 
-!!! important
+!!! warning
 
     The `iptables` firewall process here has been deprecated in Rocky Linux 9.0 (still available, but likely to disappear in future releases, perhaps as early as Rocky Linux 9.1). For this reason, we recommend skipping to the `firewalld` procedure below if you are doing this on 9.0 or better. 
 

--- a/docs/guides/contribute/mkdocs_lsyncd.md
+++ b/docs/guides/contribute/mkdocs_lsyncd.md
@@ -61,7 +61,7 @@ First, get into the container with:
 lxc exec mkdocs bash
 ```
 
-!!! important "Changes in requirements.txt for 8.x"
+!!! warning "Changes in requirements.txt for 8.x"
 
     The current `requirements.txt` will require a newer version of Python than what is installed by default in Rocky Linux 8.5 or 8.6. To be able to install all the other dependencies, do the following: 
 

--- a/docs/guides/contribute/navigation.md
+++ b/docs/guides/contribute/navigation.md
@@ -49,7 +49,7 @@ Doing this effectively requires:
 * Linking to the `docs` folder within your cloned documentation repository (you can also just modify the mkdocs.yml file if you wish to load the correct folder, but linking keeps your mkdocs environment cleaner)
 * Running `mkdocs serve` within your clone of docs.rockylinux.org
 
-!!! Hint
+!!! tip
 
     You can build totally separate environments for `mkdocs` by using either of these two procedures as well:
 

--- a/docs/guides/custom-linux-kernel.md
+++ b/docs/guides/custom-linux-kernel.md
@@ -151,7 +151,7 @@ The Linux kernel source tree contains several files named Makefile (a makefile i
 These makefiles help to glue together the thousands of other files that make up the kernel source. What is more important to us here is that the makefiles also contain targets. The targets are the commands, or directives, that are executed by the make program.
 
 
-!!! Caution "Caution: Avoid Needless Kernel Upgrades"
+!!! warning "warning: Avoid Needless Kernel Upgrades"
 
     Bear in mind that if you have a working system that is stable and well behaved, there is little reason to upgrade the kernel unless one of these conditions holds for you:
 

--- a/docs/guides/database/database_mariadb-server.md
+++ b/docs/guides/database/database_mariadb-server.md
@@ -44,7 +44,7 @@ Next, run this command:
 
 `mysql_secure_installation`
 
-!!! hint
+!!! tip
 
     The version of mariadb-server that comes enabled by default in Rocky Linux 8.5 is 10.3.32. You can install 10.5.13 by enabling the module:
 

--- a/docs/guides/email/postfix_reporting.md
+++ b/docs/guides/email/postfix_reporting.md
@@ -39,7 +39,7 @@ Aside from postfix, we will need _mailx_ for testing our ability to send emails.
 
 `dnf install postfix mailx`
 
-!!! important "Rocky Linux 9.0 Changes"
+!!! warning "Rocky Linux 9.0 Changes"
 
     This procedure works perfectly fine in Rocky Linux 9.0. The difference here is where the `mailx` command comes from. While you can install it by name in 8.x, `mailx` comes from the appstream package `s-nail` in 9.0. To install the needed packages, you need to use:
 

--- a/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
+++ b/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
@@ -24,7 +24,7 @@ _vsftpd_ is the  Very Secure FTP Daemon (FTP being the file transfer protocol). 
 
 _vsftpd_ allows for the use of virtual users with pluggable authentication modules (PAM). These virtual users don't exist in the system, and have no other permissions except to use FTP. This means that if a virtual user gets compromised, the person with those credentials would have no other permissions once they gained access. Using this setup is very secure indeed, but does require a bit of extra work.
 
-!!! hint "Consider `sftp`"
+!!! tip "Consider `sftp`"
 
     Even with the security settings used here to set up `vsftpd`, you may want to consider `sftp` instead. `sftp` will encrypt the entire connection stream and is more secure for this reason. We've created a document [here](../sftp) that deals with setting up `sftp` and the locking down SSH. 
 

--- a/docs/guides/file_sharing/sftp.md
+++ b/docs/guides/file_sharing/sftp.md
@@ -34,7 +34,7 @@ Taking all of these steps will allow you to offer secure SFTP access for your cu
 
     From there on, that process or program can *only* access that folder and its subfolders.
 
-!!! hint "Updates for Rocky Linux 8.6"
+!!! tip "Updates for Rocky Linux 8.6"
 
     This document has been updated to include new changes that came out with version 8.6 that will make this procedure even safer. If you are using 8.6, then there are specific sections in the document below, prefixed with "8.6 -". For clarity sake, the sections specific to Rocky Linux 8.5 have been prefixed with "8.5 - ". Other than those sections specifically prefixed, this document is generic for both versions of the OS.
 
@@ -260,7 +260,7 @@ passwd myfixed
 
 ### SSH Configuration
 
-!!! caution
+!!! warning
 
     Before we start this next process, it is highly recommended that you make a backup of the system file we are going to be modifying: `/etc/ssh/sshd_config`. Breaking this file and not being able to go back to the original could cause you a world of heartache!
 
@@ -486,7 +486,7 @@ A couple of things to know about the script and about an SFTP change root in gen
 
 The SFTP change root requires that the path given in the `sshd_config` is owned by root. For this reason, we do not need the `html` directory added to the end of the path. Once the user is authenticated, the change root will switch the user's home directory, in this case the `../html` directory, to whichever domain we are entering. Our script has appropriately changed the owner of the `../html` directory to the sftpuser and the apache group.
 
-!!! attention "Script Compatibility"
+!!! warning "Script Compatibility"
 
     While you can use the script that we created for Rocky Linxux 8.5 on 8.5, 8.6 or 9.0 successfully, the same cannot be said for the script for 8.6 and 9.0. Since the drop in configuration file option (`Include` directive) was not enabled in 8.5, attempting to use the script written for those newer versions in Rocky Linux 8.5 will fail.
 
@@ -565,7 +565,7 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ```
 
-!!! hint
+!!! tip
 
     For real domains, you would want to populate your DNS servers with the hosts above. You can, though, use this *Poor Man's DNS* for testing any domain, even one that hasn't been taken live on real DNS servers.
 

--- a/docs/guides/interoperability/import_rocky_to_wsl.md
+++ b/docs/guides/interoperability/import_rocky_to_wsl.md
@@ -50,18 +50,18 @@ This feature should be available on every supported Windows 10 and 11 version ri
         wsl --import <machine-name> <path-to-vm-dir> <path-to/rocky-9-image.tar.xz> --version 2
         ```
 
-!!! hint "WSL vs. WSL 2"
+!!! tip "WSL vs. WSL 2"
 
     Generally speaking WSL 2 should be faster than WSL, but that might differ from use-case to use-case.
 
-!!! hint "Windows Terminal"
+!!! tip "Windows Terminal"
 
     If you have Windows Terminal installed, the new WSL distro name will appear as an option on the pull-down menu, which is quite handy for launching in the future. You can then customize it with colors, fonts, etc.
 
-!!! hint "systemd"
+!!! tip "systemd"
 
     Microsoft finally decided to bring systemd into the WSL. This feature is in the new WSL version from the Microsoft Store. You only need to add `systemd=true` to the `boot` ini section in the `/etc/wsl.conf` file! ([ref.](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/#set-the-systemd-flag-set-in-your-wsl-distro-settings))
 
-!!! hint "Microsoft Store"
+!!! tip "Microsoft Store"
 
     Currently there is no image in the Microsoft Store, if you want to help with bringing it to there join the conversation in the Mattermost SIG/Containers channel! There has been [some effort](https://github.com/rocky-linux/WSL-DistroLauncher) a long time ago, which can get picked up again.

--- a/docs/guides/network/basic_network_configuration.md
+++ b/docs/guides/network/basic_network_configuration.md
@@ -70,7 +70,7 @@ You can't do much with a computer these days without network connectivity. Wheth
 
     Note at the top of the configuration file the reference to `keyfile` followed by `ifcfg-rh`. This means that `keyfile` is the default. Any time you run any of the `NetworkManager` tools to configure an interface (example: `nmcli` or `nmtui`), it will automatically build or update key files.
 
-    !!! Hint "Configuration Storage Location"
+    !!! tip "Configuration Storage Location"
 
         In Rocky Linux 8, the storage location for network configuration was in `/etc/sysconfig/Network-Scripts/`.
         With Rocky Linux 9, the new default storage location for the key files is in `/etc/NetworkManager/system-connections`. 
@@ -100,7 +100,7 @@ You can't do much with a computer these days without network connectivity. Wheth
     ```
 
 
-    !!! hint "**Tips:**"  
+    !!! tip "**Tips:**"  
 
         There are a few ways or mechanisms by which systems can be assigned their IP configuration information.
         The two most common methods are - **Static IP configuration** scheme and **Dynamic IP configuration** scheme.
@@ -228,7 +228,7 @@ You can't do much with a computer these days without network connectivity. Wheth
     ip a
     ```
 
-    !!! hint "**Pro tips:**"
+    !!! tip "**Pro tips:**"
 
         * use the `-c` flag to get a more readable coloured output: `ip -c a`.
 	    * `ip` accepts abbreviation so `ip a`, `ip addr` and `ip address` are equivalent
@@ -394,7 +394,7 @@ You can't do much with a computer these days without network connectivity. Wheth
 
     The interface's name is **enp1s0** so this file's name will be `/etc/sysconfig/network-scripts/ifcfg-enp1s0`.
 
-    !!! hint "**Tips:**"  
+    !!! tip "**Tips:**"  
 
         There are a few ways or mechanisms by which systems can be assigned their IP configuration information. The two most common methods are - **Static IP configuration** scheme and **Dynamic IP configuration** scheme.
 
@@ -466,7 +466,7 @@ You can't do much with a computer these days without network connectivity. Wheth
 
     From the output above, we can determine that NetworkManager manages a connection (`NAME`) called `enp1s0` that maps to the physical device (`DEVICE`) `enp1s0`.
 
-    !!! hint "Connection name"
+    !!! tip "Connection name"
 
         In this example, both the connection and device share the same name, but this may not always be the case. It is common to see a connection called `System eth0` that maps to a device called `eth0`, for example.
 
@@ -517,7 +517,7 @@ You can't do much with a computer these days without network connectivity. Wheth
     [user@server ~]$ sudo nmcli connection modify enp1s0 ipv4.method manual
     ```
 
-    !!!hint "When does the connection get updated?"
+    !!!tip "When does the connection get updated?"
 
         `nmcli connection modify` will not modify the *runtime* configuration, but update the `/etc/sysconfig/network-scripts` configuration files with the appropriate values based on what you have told `nmcli` to configure.
 
@@ -571,7 +571,7 @@ You can't do much with a computer these days without network connectivity. Wheth
     ip a
     ```
 
-    !!! hint "**Pro tips:**"
+    !!! tip "**Pro tips:**"
 
         * use the `-c` flag to get a more readable coloured output: `ip -c a`.
 	    * `ip` accepts abbreviation so `ip a`, `ip addr` and `ip address` are equivalent

--- a/docs/guides/package_management/index.md
+++ b/docs/guides/package_management/index.md
@@ -6,6 +6,6 @@ title: Introduction
 
 This section of the documentation is dedicated to package builds.
 
-!!! caution
+!!! warning
 
     Documents in this section are older and are probably in need of a re-write. If you use these instructions and have problems, please report the issues so that these documents can be properly modified. You can report any issues [here](https://chat.rockylinux.org/rocky-linux/channels/documentation).

--- a/docs/guides/proxies/pound.md
+++ b/docs/guides/proxies/pound.md
@@ -10,7 +10,7 @@ tags:
 
 # Pound Proxy Server
 
-!!! important "Pound Missing from EPEL-9"
+!!! warning "Pound Missing from EPEL-9"
 
     As of this writing, on Rocky Linux 9.0, Pound cannot be installed from the EPEL repository. While there are sources out there for SRPM packages, we can't verify the integrity of these sources. For this reason, we do not recommend installing the Pound proxy server on Rocky Linux 9.0 at this time. This may change if the EPEL once again picks up Pound.  Use this procedure specifically for Rocky Linux 8.x versions.
 
@@ -36,7 +36,7 @@ The following are minimum requirements for using this procedure:
 * We are assuming that you are using Rocky Linux servers or containers for everything here.
 * While we make all kinds of statements regarding `https` below, this guide only deals with the `http` service. To properly do `https`, you'll need to configure your pound server with a real certificate from a real certificate authority.
 
-!!! hint
+!!! tip
 
     If you don't have either of these servers installed, you can do so on a container environment (LXD or Docker) or on bare metal, and get them up and running. For this procedure, you merely need to install them with their respective packages, and enable and start the services. We won't be modifying them significantly in any way.
 
@@ -207,7 +207,7 @@ Once you have your web services up and running and listening on the right ports 
 systemctl enable --now pound
 ```
 
-!!! attention
+!!! warning
 
     Using Nginx and Apache, as we are doing here for demonstration, will mean that the Nginx server will almost always respond first. For this reason, to test effectively, you will need to assign a low priority to the Nginx server so that you will be able to see both screens. This speaks volumes about the speed of Nginx over Apache. To change the priority for the Nginx server, you just need to add a priority (1-9, with 9 being the lowest priority) in the "BackEnd" section for the Nginx server like this:
 

--- a/docs/guides/security/dnf_automatic.md
+++ b/docs/guides/security/dnf_automatic.md
@@ -17,7 +17,7 @@ For these reasons, it is reasonable to automate the download and application of 
 
 The security of your information system will be strengthened. `dnf-automatic` is an additional tool that will allow you to achieve this.
 
-!!! hint "If you are worried..."
+!!! tip "If you are worried..."
 
     Years ago, applying updates automatically like this would have been a recipe for disaster. There were many times where an update applied might cause issues. That still happens rarely, when an update of a package removes a deprecated feature that is being used on the server, but for the most part, this simply isn't an issue these days. That said though, if you still feel uncomfortable letting `dnf-automatic` handle the updates, consider using it to download and/or notify you that updates are available. That way your server doesn't remain unpatched for long. These features are `dnf-automatic-notifyonly` and `dnf-automatic-download`
 

--- a/docs/guides/security/firewalld.md
+++ b/docs/guides/security/firewalld.md
@@ -98,7 +98,7 @@ Before this zone can actually be used, we need to reload the firewall:
 
 `firewall-cmd --reload`
 
-!!! hint
+!!! tip
 
     A note about custom zones: If you need to add a zone that will be a trusted zone, but will only contain a particular source IP or interface and no protocols or services, and the "trusted" zone doesn't work for you, probably because you've already used it for something else, etc.  You can add a custom zone to do this, but you must change the target of the zone from "default" to "ACCEPT" (REJECT or DROP can also be used, depending on your goals). Here's an example using a bridge interface (lxdbr0 in this case) on an LXD machine.
 

--- a/docs/guides/security/ssh_public_private_keys.md
+++ b/docs/guides/security/ssh_public_private_keys.md
@@ -78,7 +78,7 @@ If so, we are now ready to either create or append the *authorized_keys* file in
 
 `ls -a .ssh`
 
-!!! attention "Important!"
+!!! warning "Important!"
 
     Make sure you read everything below carefully. If you are not sure if you will break something, then make a backup copy of authorized_keys (if it exists) on each of the machines before continuing.
 

--- a/docs/guides/web/apache-sites-enabled.md
+++ b/docs/guides/web/apache-sites-enabled.md
@@ -16,7 +16,7 @@ tags:
 * A server running Rocky Linux
 * Knowledge of the command-line and text editors (This example uses *vi*, but can be adapted to your favorite editor.)
 
-    !!! hint
+    !!! tip
         If you'd like to learn about the vi text editor, [here's a handy tutorial](https://www.tutorialspoint.com/unix/unix-vi-editor.htm).
 
 * Basic knowledge about installing and running web services

--- a/docs/guides/web/nginx-multisite.md
+++ b/docs/guides/web/nginx-multisite.md
@@ -32,12 +32,12 @@ This is everything you'll need:
 * A Rocky Linux server connected to the internet, with Nginx already running on it. If you haven't gotten that far, you can follow [our guide to installing Nginx](nginx-mainline.md) first.
 * Some comfort with doing things on the command line, and a terminal-based text editor like `nano` installed.
 
-    !!! hint "In a pinch"
+    !!! tip "In a pinch"
         ... you could use something like Filezilla or WinSCP — and a regular GUI-based text editor — to replicate most of these steps, but we'll be doing things the nerdy way in this tutorial.
 
 * At least one domain pointed at your server for one of the test websites. You can use either a second domain or a subdomain for the other.
 
-    !!! hint
+    !!! tip
         If you're doing all of this on a local server, adjust your hosts file as necessary to create simulated domain names. Instructions below.
 
 * We are assuming that you're running Nginx on a bare metal server or regular VPS, and that SELinux is running. All instructions will be compatible with SELinux by default.


### PR DESCRIPTION
* some aliased admonition types have been deprecated by mkdocs
* because of this, some of our documents are using invalid admonition types and they are not displaying the appropriate colored box (defaults to blue as note)
* wrote a script to identify the files and modify the admonition
* verified no unintentional consequences from the script affected any files
* 26 files affected by the changes

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

