### PR TITLE
Requested changes to NvChad 2.0 procedure

### DIFF
--- a/docs/books/nvchad/.pages
+++ b/docs/books/nvchad/.pages
@@ -6,4 +6,3 @@ nav:
     - ... | install_nvchad*.md
     - ... | nerd_fonts*.md
     - NvChad UI: nvchad_ui
-    - Customisation: custom

--- a/docs/books/nvchad/additional_software.md
+++ b/docs/books/nvchad/additional_software.md
@@ -2,7 +2,7 @@
 title: Additional Software
 author: Franco Colussi
 contributors: Steven Spencer
-tested with: 8.6, 9.0
+tested with: 8.7, 9.1
 tags:
     - nvchad
     - coding
@@ -16,7 +16,19 @@ There are several pieces of additional software that, while not required, will a
 
 `ripgrep` is a line-oriented search tool that recursively searches the current directory for a _regex_ (regular expression) pattern. By default, _ripgrep_ respects the rules of _gitignore_ and automatically skips hidden files/directories and binaries. Ripgrep offers excellent support on Windows, macOS and Linux, with binaries available for each release.
 
-Ripgrep is software written in _Rust_ and is installable with the `cargo` utility. Note, however, that `cargo` is not installed by the default installation of _rust_ so you have to install it explicitly.
+### Install RipGrep from EPEL
+
+In both Rocky Linux 8 and 9, you can install RipGrep from the EPEL. To do this, install the `epel-release,` upgrade the system, and then install `ripgrep.`:
+
+```
+sudo dnf install -y epel-release
+sudo dnf upgrade
+sudo dnf install ripgrep
+```
+
+### Install RipGrep using `cargo`
+
+Ripgrep is software written in _Rust_ and is installable with the `cargo` utility. Note, however, that `cargo` is not installed by the default installation of _rust_ so you have to install it explicitly. If you run into errors using this method, revert back to installing from the EPEL.
 
 ```bash
 dnf install rust cargo
@@ -33,6 +45,8 @@ The installation will save the `rg` executable in the `~/.cargo/bin` folder whic
 ```bash
 ln -s ~/.cargo/bin/rg ~/.local/bin/
 ```
+
+## RipGrep Verification
 
 At this point we can check that everything is okay with:
 

--- a/docs/books/nvchad/index.md
+++ b/docs/books/nvchad/index.md
@@ -2,7 +2,7 @@
 title: Overview
 author: Franco Colussi
 contributors: Steven Spencer
-tested with: 8.6, 9.0
+tested with: 8.7, 9.1
 tags:
   - nvchad
   - coding
@@ -10,10 +10,6 @@ tags:
 ---
 
 # Introduction
-
-!!! warning
-
-    With the release of version 2.0 of NvChad the custom configuration proposed in this guide is no longer compatible and indeed would break the configuration. Pending the necessary changes we caution **against applying** the instructions contained here on a version 2.0 installation.
 
 Throughout this book, you will find ways to implement Neovim, along with NvChad, to create a fully functional **I**ntegrated **D**evelopment **E**nvironment (IDE).
 

--- a/docs/books/nvchad/install_nvchad.md
+++ b/docs/books/nvchad/install_nvchad.md
@@ -2,7 +2,7 @@
 title: Install NvChad
 author: Franco Colussi
 contributors: Steven Spencer
-tested with: 9.0
+tested with: 8.7, 9.1
 tags:
   - nvchad
   - coding

--- a/docs/books/nvchad/install_nvim.md
+++ b/docs/books/nvchad/install_nvim.md
@@ -2,7 +2,7 @@
 title: Install Neovim
 author: Franco Colussi
 contributors: Steven Spencer
-tested with: 8.6, 9.0
+tested with: 8.7, 9.1
 tags:
   - nvchad
   - nvim
@@ -90,7 +90,7 @@ Now verify you have the correct version with the `nvim -v` command, which should
 
 ```txt
 nvim -v
-NVIM v0.8.0-dev-877-g35653e6bc
+NVIM v0.8.3
 Build type: RelWithDebInfo
 LuaJIT 2.1.0-beta3
 ```
@@ -102,28 +102,30 @@ Installing from precompiled package, as above, provides `nvim` only for the user
 We first install the packages required for compilation:
 
 ```bash
-dnf install ninja-build libtool autoconf automake cmake gcc gcc-c++ make pkgconfig unzip patch gettext curl
+dnf install ninja-build libtool autoconf automake cmake gcc gcc-c++ make pkgconfig unzip patch gettext curl git
 ```
 
-Once we have installed the necessary packages we need to download the Neovim sources that are distributed with _Git_. In our example we will have a folder already created for this purpose in `/home/user/lab/build`. Adapt your commands according to the structure you choose.
+Once we have installed the necessary packages we need to create a folder to build neovim from and change into it:
 
 The Neovim clone, by default, is synchronized with the Neovim development branch (at the time of this writing, version 8.0). To compile the stable version we will have to switch to the corresponding branch before cloning with:
 
 ```bash
+mkdir ~/lab/build
 cd ~/lab/build
-git checkout stable
 ```
 
-And subsequently clone the repository:
+Now clone the repository:
 
 ```bash
 git clone https://github.com/neovim/neovim
 ```
 
-Once the operation is finished, we will have a folder named _neovim_ containing all the necessary files. The next step is to configure and compile the sources. This is done with the `make` command in the _neovim_ folder we created:
+Once the operation is finished, we will have a folder named _neovim_ containing all the necessary files. The next step is to checkout the stable branch, and then configure and compile the sources with the `make` command.
+
 
 ```bash
 cd ~/lab/build/neovim/
+git checkout stable
 make CMAKE_BUILD_TYPE=RelWithDebInfo
 ```
 
@@ -148,13 +150,13 @@ And verifying the version:
 
 ```bash
 nvim --version
-NVIM v0.8.0-dev-885-ga5ed89c97
+NVIM v0.8.3
 Build type: RelWithDebInfo
 LuaJIT 2.1.0-beta3
 ....
 ```
 
-As you can see from the command excerpt above, an installation of the development version was performed here. Both versions, stable and development, work perfectly with NvChad on Rocky Linux 9.
+As you can see from the command excerpt above, an installation of the stable version was performed here. Both versions, stable and development, work perfectly with NvChad on Rocky Linux 9.
 
 #### Uninstall
 


### PR DESCRIPTION
* remove "Customizations" from the `.pages` file (these no-longer work with 2.0)
* In `additional_software.md` add a section for installing RipGrep from the EPEL, which seems to work better than the cargo procedure overall
* remove the admonition recently added to the `index.md` page, as the issue has been resolved with the current rewrites and edits
* Made a change to the `install_nvim.md` file in the "Install from Source" section so that the `git clone` and `git checkout` commands were in the correct order.
* Tested all steps with RL 8.7 and 9.1 and they all work, so updated the "tested with:" meta to include both versions0

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

