### PR TITLE
modified command - mapping no longer available

### DIFF
--- a/docs/books/nvchad/index.md
+++ b/docs/books/nvchad/index.md
@@ -43,7 +43,7 @@ As the developers of NvChad are keen to point out, the project is only intended 
 
 - **Extremely Configurable.** Due to the modularity derived from the base application (NeoVim), the editor can be adapted perfectly to one's needs. Keep in mind, however, that when we talk about customization we are referring to functionality, and not to the appearance of the interface.
 
-- **Automatic update mechanism.** The editor comes with a mechanism (through the use of _git_) that allows updates with a simple `<leader> + uu` command.
+- **Automatic update mechanism.** The editor comes with a mechanism (through the use of _git_) that allows updates with a simple `:NvChadUpdate` command.
 
 - **Powered by Lua.** NvChad's configuration is written entirely in _lua_, which allows it to integrate seamlessly into Neovim's configuration by taking advantage of the full potential of the editor on which it is based.
 


### PR DESCRIPTION
the `<leader> + uu` mapping is no longer available in version 2.0.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

