### PR TITLE
Correct anchor ID link

### DIFF
--- a/docs/guides/contribute/rockydocs_webdev_v2.md
+++ b/docs/guides/contribute/rockydocs_webdev_v2.md
@@ -17,7 +17,7 @@ Running a local copy of the documentation website might be useful in the followi
 
 ## Create the content environment
 
-1. Make sure that the prerequisites are satisfied. If not please skip to the "[Setup the prerequisites](##Setup the prerequisites)" section and then return here. 
+1. Make sure that the prerequisites are satisfied. If not please skip to the "[Setup the prerequisites](#setup-the-prerequisites)" section and then return here. 
 
 2. Change the current working directory on your local system to a folder where you intend to do your writing. 
   We'll refer to this directory as


### PR DESCRIPTION
Correct the "Setup the prerequisites" anchored link. 
`## -> # `, `Setup -> setup` , and `%20 -> -`  
There are other ways to correct this, like changing the anchor ID to actually use uppercase S and spaces for example, depending on the style you prefer for consistency sake etc.

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

