### PR TITLE
Remove trailing whitespace II

### DIFF
--- a/docs/books/learning_ansible/01-basic.md
+++ b/docs/books/learning_ansible/01-basic.md
@@ -13,13 +13,13 @@ In this chapter you will learn how to work with Ansible.
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: Implement Ansible;       
-:heavy_check_mark: Apply configuration changes on a server;   
-:heavy_check_mark: Create first Ansible playbooks;   
+:heavy_check_mark: Implement Ansible;
+:heavy_check_mark: Apply configuration changes on a server;
+:heavy_check_mark: Create first Ansible playbooks;
 
 :checkered_flag: **ansible**, **module**, **playbook**
 
-**Knowledge**: :star: :star: :star:     
+**Knowledge**: :star: :star: :star:
 **Complexity**: :star: :star:
 
 **Reading time**: 30 minutes

--- a/docs/books/learning_ansible/02-advanced.md
+++ b/docs/books/learning_ansible/02-advanced.md
@@ -10,14 +10,14 @@ In this chapter you will continue to learn how to work with Ansible.
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: work with variables;       
-:heavy_check_mark: use loops;   
-:heavy_check_mark: manage state changes and react to them;   
+:heavy_check_mark: work with variables;
+:heavy_check_mark: use loops;
+:heavy_check_mark: manage state changes and react to them;
 :heavy_check_mark: manage asynchronous tasks.
 
 :checkered_flag: **ansible**, **module**, **playbook**
 
-**Knowledge**: :star: :star: :star:     
+**Knowledge**: :star: :star: :star:
 **Complexity**: :star: :star:
 
 **Reading time**: 30 minutes
@@ -493,7 +493,7 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 ```
 
@@ -545,7 +545,7 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 ```
 
@@ -565,7 +565,7 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 * Externalize variables in a `vars.yml` file
@@ -622,7 +622,7 @@ With `dict2items`:
     - name: Print a dictionary variable with a loop
       debug:
         msg: "{{item.key }} | The {{ item.value.name }} will be installed with the packages {{ item.value.rpm }}"
-      loop: "{{ service | dict2items }}"              
+      loop: "{{ service | dict2items }}"
 ```
 
 ```
@@ -642,7 +642,7 @@ ok: [192.168.1.11] => (item={'key': 'db', 'value': {'name': 'mariadb', 'rpm': 'm
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 ```
 
@@ -660,7 +660,7 @@ With `list`:
       debug:
         msg: "The {{ item.name }} will be installed with the packages {{ item.rpm }}"
       loop: "{{ service.values() | list}}"
-~                                                 
+~
 ```
 
 ```
@@ -680,7 +680,7 @@ ok: [192.168.1.11] => (item={'name': 'mariadb', 'rpm': 'mariadb-server'}) => {
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 * Print the value of `service.web` only when `type` equals to `web`.
@@ -722,7 +722,7 @@ TASK [Print a dictionary variable] *********************************************
 skipping: [192.168.1.11]
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
 
 $ ansible-playbook --extra-vars "type=db" display-dict.yml
 
@@ -740,5 +740,5 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP *********************************************************************************************
-192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+192.168.1.11               : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
 ```

--- a/docs/books/learning_ansible/03-working-with-files.md
+++ b/docs/books/learning_ansible/03-working-with-files.md
@@ -10,13 +10,13 @@ In this chapter you will learn how to manage files with Ansible.
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: modify the content of file;       
-:heavy_check_mark: upload files to the targeted servers;   
-:heavy_check_mark: retrieve files from the targeted servers.   
+:heavy_check_mark: modify the content of file;
+:heavy_check_mark: upload files to the targeted servers;
+:heavy_check_mark: retrieve files from the targeted servers.
 
 :checkered_flag: **ansible**, **module**, **files**
 
-**Knowledge**: :star: :star:     
+**Knowledge**: :star: :star:
 **Complexity**: :star:
 
 **Reading time**: 20 minutes

--- a/docs/books/learning_ansible/04-ansible-galaxy.md
+++ b/docs/books/learning_ansible/04-ansible-galaxy.md
@@ -10,12 +10,12 @@ In this chapter you will learn how to use, install, and manage Ansible roles and
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: install and manage collections.       
-:heavy_check_mark: install and manage roles.   
+:heavy_check_mark: install and manage collections.
+:heavy_check_mark: install and manage roles.
 
 :checkered_flag: **ansible**, **ansible-galaxy**, **roles**, **collections**
 
-**Knowledge**: :star: :star:      
+**Knowledge**: :star: :star:
 **Complexity**: :star: :star: :star:
 
 **Reading time**: 40 minutes
@@ -197,7 +197,7 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP **********************************************************************************************
-192.168.1.11               : ok=31   changed=1    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0  
+192.168.1.11               : ok=31   changed=1    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
 ```
 
 Pretty easy for such a complex process, isn't it?
@@ -318,7 +318,7 @@ TASK [rocky8 : Create default user] ********************************************
 changed: [localhost]
 
 PLAY RECAP *********************************************************************************************
-localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 Congratulations! You are now able to create great things with a playbook of only a few lines.
@@ -371,7 +371,7 @@ TASK [rocky8 : Uninstall default packages (can be overridden) []] **************
 ok: [localhost]
 
 PLAY RECAP *********************************************************************************************
-localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 You can now override the `rocky8_remove_packages` in your playbook and uninstall for example `cockpit`:
@@ -412,7 +412,7 @@ TASK [rocky8 : Uninstall default packages (can be overridden) ['cockpit']] *****
 changed: [localhost]
 
 PLAY RECAP *********************************************************************************************
-localhost                  : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+localhost                  : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 Obviously, there is no limit to how much you can improve your role. Imagine that for one of your servers, you need a package that is in the list of those to be uninstalled. You could then, for example, create a new list that can be overridden and then remove from the list of packages to be uninstalled those in the list of specific packages to be installed by using the jinja `difference()` filter.
@@ -484,7 +484,7 @@ We can now use the newly available module `yum_versionlock`:
 
     - name: Display locks
       debug:
-        var: locks.meta.packages                            
+        var: locks.meta.packages
 ```
 
 ```
@@ -509,7 +509,7 @@ ok: [192.168.1.11] => {
 }
 
 PLAY RECAP **********************************************************************************************
-192.168.1.11               : ok=4    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+192.168.1.11               : ok=4    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 ```
 

--- a/docs/books/learning_ansible/05-deployments.md
+++ b/docs/books/learning_ansible/05-deployments.md
@@ -10,15 +10,15 @@ In this chapter you will learn how to deploy applications with the Ansible role 
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: Implement Ansistrano;       
-:heavy_check_mark: Configure Ansistrano;       
-:heavy_check_mark: Use shared folders and files between deployed versions;       
-:heavy_check_mark: Deploying different versions of a site from git;        
-:heavy_check_mark: React between deployment steps.          
+:heavy_check_mark: Implement Ansistrano;
+:heavy_check_mark: Configure Ansistrano;
+:heavy_check_mark: Use shared folders and files between deployed versions;
+:heavy_check_mark: Deploying different versions of a site from git;
+:heavy_check_mark: React between deployment steps.
 
 :checkered_flag: **ansible**, **ansistrano**, **roles**, **deployments**
 
-**Knowledge**: :star: :star:      
+**Knowledge**: :star: :star:
 **Complexity**: :star: :star: :star:
 
 **Reading time**: 40 minutes
@@ -258,7 +258,7 @@ TASK [ansistrano.deploy : ANSISTRANO | Change softlink to new release]
 TASK [ansistrano.deploy : ANSISTRANO | Clean up releases]
 
 PLAY RECAP ********************************************************************************************************************************************************************************************************
-192.168.1.11               : ok=25   changed=8    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   
+192.168.1.11               : ok=25   changed=8    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0
 
 ```
 

--- a/docs/books/learning_ansible/06-large-scale-infrastructure.md
+++ b/docs/books/learning_ansible/06-large-scale-infrastructure.md
@@ -10,12 +10,12 @@ In this chapter you will learn how to scale your configuration management system
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: Organize your code for large infrastructure;   
-:heavy_check_mark: Apply all or part of your configuration management to a group of nodes;   
+:heavy_check_mark: Organize your code for large infrastructure;
+:heavy_check_mark: Apply all or part of your configuration management to a group of nodes;
 
 :checkered_flag: **ansible**, **config management**, **scale**
 
-**Knowledge**: :star: :star: :star:       
+**Knowledge**: :star: :star: :star:
 **Complexity**: :star: :star: :star: :star:
 
 **Reading time**: 30 minutes
@@ -235,7 +235,7 @@ TASK [roles/functionality2 : Task in functionality 2] **************************
 skipping: [client1]
 
 PLAY RECAP ******************************************************************************************************
-client1                    : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+client1                    : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
 ```
 
 As you can see, by default, only the tasks of the `functionality1` role are played.
@@ -268,7 +268,7 @@ ok: [client1] => {
 }
 
 PLAY RECAP ******************************************************************************************************
-client1                    : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+client1                    : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 Try to apply only `functionality2`:
@@ -287,7 +287,7 @@ ok: [client1] => {
 }
 
 PLAY RECAP ******************************************************************************************************
-client1                    : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+client1                    : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 Let's run on the whole inventory:
@@ -316,8 +316,8 @@ ok: [client1] => {
 skipping: [client2]
 
 PLAY RECAP ******************************************************************************************************
-client1                    : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
-client2                    : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+client1                    : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+client2                    : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
 ```
 
 As you can see, `functionality2` is only played on the `client1`.

--- a/docs/books/learning_ansible/07-working-with-filters.md
+++ b/docs/books/learning_ansible/07-working-with-filters.md
@@ -12,12 +12,12 @@ In this chapter you will learn how to transform data with jinja filters.
 
 **Objectives**: In this chapter you will learn how to:
 
-:heavy_check_mark: Transform data structures as dictionaries or lists;  
-:heavy_check_mark: Transform variables.  
+:heavy_check_mark: Transform data structures as dictionaries or lists;
+:heavy_check_mark: Transform variables.
 
 :checkered_flag: **ansible**, **jinja**, **filters**
 
-**Knowledge**: :star: :star: :star:       
+**Knowledge**: :star: :star: :star:
 **Complexity**: :star: :star: :star: :star:
 
 **Reading time**: 20 minutes


### PR DESCRIPTION
Automated with `sed -i -E 's/^(.*\S|)\s+$/\1/' *.md`.

I just removed the international file from [the original pull request](https://github.com/rocky-linux/documentation/pull/1143) so now everything should be okay 🤞 

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

