### PR TITLE
Updated the wget installation link

### DIFF
--- a/docs/labs/sys_admin_1/lab7-software_management.md
+++ b/docs/labs/sys_admin_1/lab7-software_management.md
@@ -162,7 +162,7 @@ It looks like wget is not installed on our demo system.
 
 ```
 curl --output "wget-1.19.5-10.el8.x86_64.rpm" \
-http://download.rockylinux.org/pub/rocky/8.5/AppStream/x86_64/os/Packages/w/wget-1.19.5-10.el8.x86_64.rpm
+https://dl.rockylinux.org/vault/rocky/8.5/AppStream/x86_64/os/Packages/w/wget-1.19.5-10.el8.x86_64.rpm
 ```
 8. Use the ls command to make sure that the package was downloaded into your current directory. Type:
 


### PR DESCRIPTION
Hi Team,
I was checking the Sysadmin tasks and found a problem with the installation link for the `wget` package. 

https://docs.rockylinux.org/labs/sys_admin_1/lab7-software_management/#installing-querying-and-uninstalling-packages

It seems to have moved to a different path. 

```
This content has been moved to the Rocky Linux Vault

https://dl.rockylinux.org/vault/rocky/8.5/
```

I updated the link. Please review it. 

Thanks,

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

