### PR TITLE
# Style replacements and formatting

### DIFF
--- a/docs/guides/web/apache-sites-enabled.md
+++ b/docs/guides/web/apache-sites-enabled.md
@@ -1,20 +1,20 @@
 ---
-title: Apache Multisite
+title: Apache multiple site
 author: Steven Spencer
 contributors: Ezequiel Bruni
 tested with: 8.5, 8.6, 9.0
 tags:
   - web
   - apache
-  - multisite
+  - multiple site
 ---
 
-# Apache Web Server Multisite Setup
+# Apache web server multiple site setup
 
-## What You Need
+## What you need
 
 * A server running Rocky Linux
-* Knowledge of the command-line and text editors (This example uses *vi*, but can be adapted to your favorite editor.)
+* Knowledge of the command-line and text editors. This example uses *vi*, but use your favorite editor.
 
     !!! tip
 
@@ -24,52 +24,76 @@ tags:
 
 ## Introduction
 
-Rocky Linux has many ways for you to set up a website. This is just one method, using Apache, and is designed for use as a multisite setup on a single server. While this method is designed for multisite servers, it can also act as a base configuration for a single site server as well.
+Rocky Linux has many ways for you to set up a website. This is just one method, using Apache on a single server. The design of this method is for multiple servers on one piece of hardware, but it can also act as a base configuration for a single site server as well.
 
-Historical fact: This server setup appears to have started with Debian-based systems, but it is perfectly adaptable to any Linux OS running Apache.
+Historical fact: This server setup appears to have started with Debian-based systems, but it is perfectly adaptable to any Linux operating system running Apache.
 
-For those looking for a similar setup for Nginx, take a [look at this guide.](nginx-multisite.md)
+For those looking for a similar setup for Nginx, take a [examine this guide.](nginx-multisite.md)
 
 ## Install Apache
-You'll likely need other packages for your website. For instance, a version of PHP will almost certainly be required, and maybe a database or other package will be needed as well. Installing PHP along with httpd will get you the latest version of both from the Rocky Linux repositories.
+You'll likely need other packages for your website, such as PHP, database, or other packages. Installing PHP along with `http` will get you the most recent version from the Rocky Linux repositories.
 
-Just remember that you may need modules as well, like perhaps php-bcmath or php-mysqlind. Your web application specifications should detail what is needed. These can be installed at any time. For now, we will install httpd and PHP, as those are almost a forgone conclusion:
+Just remember that you may need modules, such as `php-bcmath` or `php-mysqlind`. Your web application specifications will dictate what you need. You can install these when needed. For now, you will install `http` and PHP, as those are almost a forgone conclusion:
 
-* From the command-line run `dnf install httpd php`
+From the command-line run:
 
-## Add Extra Directories
+```
+dnf install httpd php
+```
 
-This method uses a couple of additional directories, but they don't currently exist on the system. We need to add two directories in */etc/httpd/* called "sites-available" and "sites-enabled."
+## Add extra directories
 
-* From the command-line type `mkdir /etc/httpd/sites-available` and then `mkdir /etc/httpd/sites-enabled`
+This method uses a couple of additional directories, but they do not currently exist on the system. You need to add two directories in */etc/httpd/* called "sites-available" and "sites-enabled."
 
-* We also need a directory where our sites are going to reside. This can be anywhere, but a good way to keep things organized is to create a directory called sub-domains. To keep things simple, put this in /var/www: `mkdir /var/www/sub-domains/`
+From the command-line enter: 
+
+```
+mkdir -p /etc/httpd/sites-available /etc/httpd/sites-enabled
+```
+
+This will create both needed directories.
+
+You also need a directory where our sites are going to be. This can be anywhere, but a good way to keep things organized is to create a directory called "sub-domains". To decrease complexity, put this in /var/www: `mkdir /var/www/sub-domains/`.
 
 ## Configuration
-We also need to add a line to the very bottom of the httpd.conf file. To do this, type `vi /etc/httpd/conf/httpd.conf` and go to the bottom of the file and add `Include /etc/httpd/sites-enabled`.
 
-Our actual configuration files will reside in */etc/httpd/sites-available* and we will simply symlink to them in */etc/httpd/sites-enabled*.
+You also need to add a line to the bottom of the `httpd.conf` file. To do this, enter: 
 
-**Why do we do this?**
+```
+vi /etc/httpd/conf/httpd.conf
+```
 
-The reason here is pretty simple. Let's say you have 10 websites all running on the same server on different IP addresses. We will say, too, that site B has some major updates, and you have to make changes to the configuration for that site. Let's say as well, that there is something wrong with the changes made, so when you restart httpd to read in the new changes, httpd doesn't start.
+and go to the bottom of the file and add:
 
-Not only will the site you were working on not start, but neither will the rest of them. With this method, you can simply remove the symbolic link for the site that caused the failure, and restart httpd. It’ll start working again, and you can go to work, trying to fix the broken site configuration.
+```
+Include /etc/httpd/sites-enabled
+```
 
-It sure takes the pressure off, knowing that the phone isn't going to ring with some angry customer, or an angry boss, because a service is off-line.
+Our actual configuration files will be in */etc/httpd/sites-available* and you will symlink to them in */etc/httpd/sites-enabled*.
 
-### The Site Configuration
-The other benefit of this method is that it allows us to fully specify everything outside the default httpd.conf file. Let the default httpd.conf file load the defaults, and let your site configurations do everything else. Sweet, right? Plus again, it makes it very easy to trouble-shoot a broken site configuration.
+**Why do you do this?**
 
-Now, let's say you have a website that loads a wiki. You’ll need a configuration file, which makes the site available via port 80.
+Say you have 10 websites all running on the same server on different IP addresses. Say that site B has some major updates, and you have to make changes to the configuration for that site. Say also that something goes wrong with the changes made, and when you restart `httpd` to read in the changes, `httpd` does not start. Not only will the site you were working on not start, but neither will the rest of them. With this method, you can remove the symbolic link for the site that caused the problem, and restart `httpd`. It will start working again, and you can go to work fixing the broken site configuration.
 
-If you want to serve the website with SSL (and let's face it, we all should be doing that by now) then you need to add another (nearly identical) section to the same file, in order to enable port 443.
+It sure takes the pressure off, knowing that the telephone is not going to ring with some upset customer or boss, because a service is off-line.
 
-You can take a look at that below in the [Configuration https - Using An SSL Certificate](#https) section.
+### The site configuration
 
-So we first need to create this configuration file in *sites-available*: `vi /etc/httpd/sites-available/com.wiki.www`
+The other benefit of this method is that it allows us to fully specify everything outside the default `httpd.conf` file. The default `httpd.conf` file loads the defaults, and your site configurations do everything else. Great, right? Plus again, it makes troubleshooting a broken site configuration less complex.
 
-The configuration file configuration content would look something like this:
+Say you have a website that loads a wiki. You will need a configuration file, which makes the site available on port 80.
+
+If you want to serve the website with SSL/TLS (and face it, in most cases you do), you need to add another (nearly the same) section to that file to enable port 443.
+
+You can examine that below in the [Configuration `https` using An SSL/TLS certificate](#https) section.
+
+You first need to create this configuration file in *sites-available*: 
+
+```
+vi /etc/httpd/sites-available/com.wiki.www
+```
+
+The configuration file content will look something like this:
 
 ```apache
 <VirtualHost *:80>
@@ -95,49 +119,53 @@ The configuration file configuration content would look something like this:
         </Directory>
 </VirtualHost>
 ```
-Once the file is created, we need to write (save) it with: `shift : wq`
+When created, you need to write (save) it with <kbd>shift</kbd>+<kbd>:</kbd>+<kbd>wq</kbd>.
 
-In our example above, the wiki site is loaded from the "html" sub-directory of _your-server-hostname_, which means that the path we created in _/var/www_ (above) will need some additional directories to satisfy this:
+In the example, loading the wiki site happens from the "html" subdirectory of _your-server-hostname_, which means that the path you created in _/var/www_ (above) will need some additional directories to satisfy this:
 
-`mkdir -p /var/www/sub-domains/your-server-hostname/html`
+```
+mkdir -p /var/www/sub-domains/your-server-hostname/html
+```
 
-... which will create the entire path with a single command. Next we would want to install our files to this directory that will actually run the website. This could be something you made yourself, or an installable web application (in this case a wiki that you downloaded).
+This will create the entire path with a single command. Next you want to install your files to this directory that will actually run the website. This might be something you made yourself, or an installable web application (in this case a wiki) that you downloaded.
 
-Copy your files to the path above:
+Copy your files to the path you created:
 
-`cp -Rf wiki_source/* /var/www/sub-domains/your-server-hostname/html/`
+```
+cp -Rf wiki_source/* /var/www/sub-domains/your-server-hostname/html/
+```
 
-## <a name="https"></a>Configuration https - Using an SSL Certificate
+## <a name="https"></a>Configuration `https` using an SSL/TLS certificate
 
-As stated earlier, every web server created these days _should_ be running with SSL (AKA the secure socket layer).
+As stated earlier, every web server created these days _should_ be running with SSL/TLS (the secure socket layer).
 
-This process starts by generating a private key and a CSR (which stands for certificate signing request) and then submitting the CSR to the certificate authority to purchase the SSL certificate. The process of generating these keys is somewhat extensive, so it has its own document.
+This process starts by generating a private key and a CSR (which stands for certificate signing request) and submitting the CSR to the certificate authority to buy the SSL/TLS certificate. The process of generating these keys is somewhat extensive.
 
-If you are new to generating keys for SSL, please take a look at: [Generating SSL Keys](../security/ssl_keys_https.md)
+If you are not familiar with SSL/TLS key generation examine: [Generating SSL Keys](../security/ssl_keys_https.md)
 
-You can also use this alternate process for using an [SSL certificate from Let's Encrypt](../security/generating_ssl_keys_lets_encrypt.md)
+You can also use this alternate process, using an [SSL certificate from Let's Encrypt](../security/generating_ssl_keys_lets_encrypt.md)
 
-### Placement of the SSL keys and Certificate's
+### Placement of the SSL/TLS keys and certificates
 
-Now that you have your keys and certificate files, we need to place them logically in your file system on the web server. As we've seen with the example configuration file (above), we are placing our web files in _/var/www/sub-domains/your-server-hostname/html_.
+Since you have your keys and certificate files, you need to place them logically in your file system on the web server. As you have seen with the example configuration file, you are placing your web files in _/var/www/sub-domains/your-server-hostname/html_.
 
-We want to place our certificate and key files with the domain, but NOT in the document root, which in this case is the _html_ folder.
+You want to place your certificate and key files with the domain, but outside of the document root, which in this case is the _html_ folder.
 
-We never want our certificates and keys to potentially be exposed to the web. That would be bad!
+You never want to risk exposing your certificates and keys to the web. That would be bad!
 
-Instead, we will create a new directory structure for our SSL files, outside the document root:
+Instead, you will create a directory structure for our SSL/TLS files, outside the document root:
 
-`mkdir -p /var/www/sub-domains/your-server-hostname/ssl/{ssl.key,ssl.crt,ssl.csr}`
+```
+mkdir -p /var/www/sub-domains/your-server-hostname/ssl/{ssl.key,ssl.crt,ssl.csr}`
+```
 
 If you are new to the "tree" syntax for making directories, what the above says is:
 
-"Make a directory called ssl and then make three directories inside called ssl.key, ssl.crt, and ssl.csr."
+"Make a directory called "ssl" and make three directories inside called ssl.key, ssl.crt, and ssl.csr."
 
-Just a note ahead of time: It is not necessary for the functioning of the web server that the CSR file be stored in the tree.
+Just a note ahead of time: Storing the certificate signing request (CSR) file in the tree is not necessary, but it simplifies some things. If you ever need to re-issue the certificate from a different provider, it is a good idea to have a stored copy of the CSR file. The question becomes where can you store it so that you will remember, and storing it within the tree of your website is logical.
 
-If you ever need to re-issue the certificate from a different provider, etc., it's a good idea to have a stored copy of the CSR file. The question becomes where can you store it so that you will remember, and storing it within the tree of your website is logical.
-
-Assuming that you have named your key, csr, and crt (certificate) files with the name of your site, and that you have them stored in _/root_, we will then copy them up to their respective locations that we just created:
+Assuming that you have named your key, csr, and crt (certificate) files with the name of your site, and that you have them stored in _/root_, you will copy them up to their locations:
 
 ```
 cp /root/com.wiki.www.key /var/www/sub-domains/your-server-hostname/ssl/ssl.key/
@@ -145,13 +173,14 @@ cp /root/com.wiki.www.csr /var/www/sub-domains/your-server-hostname/ssl/ssl.csr/
 cp /root/com.wiki.www.crt /var/www/sub-domains/your-server-hostname/ssl/ssl.crt/
 ```
 
-### The Site Configuration - https
+### The site configuration - `https`
 
-Once you have generated your keys and purchased the SSL certificate, you can now move forward with the configuration of the website using your new keys.
+Once you have generated your keys and purchased the SSL/TLS certificate, you can now move forward with the configuration of the website, using your keys.
 
-For starters, let's break down the beginning of the configuration file. For instance, even though we still want to listen on port 80 (standard http) for incoming requests, we don't want any of those requests to actually go to port 80.
+For starters, break down the beginning of the configuration file. For instance, even though you still want to listen on port 80 (standard `http` port) for incoming requests, you do not want any of those requests to actually go to port 80.
 
-We want them to go to port 443 (or http secure, better known as SSL). Our port 80 configuration section will be minimal:
+You want them to go to port 443 (or "`http` secure", better known as SSL/TLS or `https`). Our port 80 configuration section will be minimal:
+
 
 ```
 <VirtualHost *:80>
@@ -161,11 +190,11 @@ We want them to go to port 443 (or http secure, better known as SSL). Our port 8
 </VirtualHost>
 ```
 
-What this says is to send any regular web request to the https configuration instead. The apache "Redirect" option shown above, can be changed to "Redirect permanent" once all testing is complete, and you can see that the site operates as you want it to. The "Redirect" we have chosen is a temporary redirect.
+What this says is to send any regular web request to the `https` configuration instead. The apache "Redirect" option shown is temporary. When testing is complete and you can see that the site is running as expected, you can change this to "Redirect permanent."
 
-A permanent redirect will be learned by search engines, and soon, any traffic to your site that comes from search engines will go only to port 443 (https) without hitting port 80 (http) first.
+A permanent redirect will teach the search engines, and soon any traffic to your site that comes from search engines will go only to port 443 (`https`) without hitting port 80 (`http`) first.
 
-Next, we need to define the https portion of the configuration file. The http section is duplicated here for clarity to show that this all happens in the same configuration file:
+Next, you need to define the `https` part of the configuration file:
 
 ```
 <VirtualHost *:80>
@@ -181,8 +210,8 @@ Next, we need to define the https portion of the configuration file. The http se
         Alias /icons/ /var/www/icons/
         # ScriptAlias /cgi-bin/ /var/www/sub-domains/your-server-hostname/cgi-bin/
 
-	CustomLog "/var/log/httpd/your-server-hostname-access_log" combined
-	ErrorLog  "/var/log/httpd/your-server-hostname-error_log"
+	CustomLog "/var/log/`http`d/your-server-hostname-access_log" combined
+	ErrorLog  "/var/log/`http`d/your-server-hostname-error_log"
 
         SSLEngine on
         SSLProtocol all -SSLv2 -SSLv3 -TLSv1
@@ -207,25 +236,28 @@ Next, we need to define the https portion of the configuration file. The http se
 </VirtualHost>
 ```
 
-So, breaking down this configuration further, after the normal portions of the configuration and down to the SSL portion:
+So, breaking down this configuration further, after the normal portions of the configuration and down to the SSL/TLS section:
 
-* SSLEngine on - simply says to use SSL
-* SSLProtocol all -SSLv2 -SSLv3 -TLSv1 - says to use all available protocols, except those that have been found to have vulnerabilities. You should research periodically which protocols are currently acceptable for use.
-* SSLHonorCipherOrder on - this deals with the next line that regarding the cipher suites, and says to deal with them in the order that they are given. This is another area where you should review the cipher suites that you want to include periodically
-* SSLCertificateFile - is exactly what it sounds like, the newly purchased and applied certificate file and its location
+* SSLEngine on - says to use SSL/TLS
+* SSLProtocol all -SSLv2 -SSLv3 -TLSv1 - says to use all available protocols, except those with vulnerabilities. You should research periodically the protocols currently acceptable for use.
+* SSLHonorCipherOrder on - this deals with the next line regarding the cipher suites, and says to deal with them in the order shown. This is another area where reviewing the cipher suites should occur periodically.
+* SSLCertificateFile - is exactly what it says: the newly purchased and applied certificate file and its location
 * SSLCertificateKeyFile - the key you generated when creating your certificate signing request
-* SSLCertificateChainFile - the certificate from your certificate provider, often referred to as the intermediate certificate.
+* SSLCertificateChainFile - the certificate from your certificate provider, often called the intermediate certificate
 
-Next, take everything live and if there are no errors starting the web service and if going to your website reveals HTTPS without errors, then you are ready to go.
+Next, take everything live and if there are no errors starting the web service and if going to your website reveals `https` without errors, you are ready to go.
 
-## Taking It Live
+## Taking it live
 
-Remember that our *httpd.conf* file is including */etc/httpd/sites-enabled* at the very end of the file, so when `httpd` restarts, it will load whatever configuration files are in that *sites-enabled* directory. Thing is, all of our configuration files are in *sites-available*.
+Remember that our *httpd.conf* file is including */etc/httpd/sites-enabled* at the end of the file. When `httpd` restarts, it will load whatever configuration files are in that *sites-enabled* directory. Thing is, all of our configuration files are in *sites-available*.
 
-That's by design, so that we can easily remove things in the event that `httpd` fails to restart. So to enable our configuration file, we need to create a symbolic link to that file in *sites-enabled* and then start or restart the web service. To do this, we use this command:
+That is by design, so that you can remove things when or if  `httpd` fails to restart. To enable our configuration file, you need to create a symbolic link to that file in *sites-enabled* and start or restart the web service. To do this, you use this command:
 
-`ln -s /etc/httpd/sites-available/your-server-hostname /etc/httpd/sites-enabled/`
+```
+ln -s /etc/httpd/sites-available/your-server-hostname /etc/httpd/sites-enabled/
+```
+
 
 This will create the link to the configuration file in *sites-enabled*, just like we want.
 
-Now just start httpd with `systemctl start httpd`. Or restart it if it’s already running: `systemctl restart httpd`, and assuming the web service restarts, you can now go and do some testing on your new site.
+Now just start `httpd` with `systemctl start httpd`. Or restart it if it is already running: `systemctl restart httpd`, and assuming the web service restarts, you can now go and do some testing on your site.


### PR DESCRIPTION
* bulleted items have no punctuation except those that have qualifying sentences immediately following them
* Sentence style capitalization applied to all headings
* Passive voice eliminated or mostly eliminated
* code blocks all use three back ticks (```) and appear on their own lines per earlier decisions made about documentation and code blocks
* SSL has been replaced with SSL/TLS as recommended by Vale dictionaries
* try to replace all conjunctions with the two words they represent (not sure if I caught them all or not!)
* name change from "Apache Multisite" to "Apache multiple site" including tags
* references of "we" have been changed to "you" in most cases (vale editor suggestion)

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

