### PR TITLE
Removed extra blank space after title

### DIFF
--- a/docs/guides/desktop/xfce_installation.md
+++ b/docs/guides/desktop/xfce_installation.md
@@ -1,5 +1,5 @@
 ---
-title: XFCE Desktop 
+title: XFCE Desktop
 author: Gerard Arthus, Steven Spencer
 contributors: Steven Spencer, Antoine Le Morvan, K.Prasad
 tested_with: 8.5, 8.6, 9.0


### PR DESCRIPTION
The blank space did not allow the frontmatter to be displayed correctly

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

