### PR TITLE
# editorial changes

### DIFF
--- a/docs/guides/email/01-email-system.md
+++ b/docs/guides/email/01-email-system.md
@@ -4,26 +4,26 @@ author: tianci li
 version: 1.0.0
 ---
 
-# Overview of E-mail system
+# Overview of email system
 
-E-mail, as one of the three major services (FTP, Web, and E-mail) at the beginning of the internet, is still used by many people today. Email first appeared in the 1960s, and email based on network transmission first appeared in 1971.
+Email, as one of the three major services (FTP, Web, and email) at the beginning of the internet, is still used by many people today. Email first appeared in the 1960s, and email based on network transmission first appeared in 1971.
 
-Unlike the email systems of commercial companies, the open-source version of the email system consists of many parts and is not a single service, which also leads to more complex email systems in GNU/Linux environments.
+Unlike commercial companies' email systems, the email system's open source version consists of many parts. It is not a single service, leading to more complex email systems in GNU/Linux environments.
 
-## The basic concept of E-mail system
+## The basic concept of email system
 
-The E-mail system mainly consists of four parts: **MUA**, **MTA**, **MRA** and **MDA**.
+The email system mainly consists of four parts: **MUA**, **MTA**, **MRA** and **MDA**.
 
-* **MUA (Mail User Agent)**: That is, mail clients for users, such as Outlook, Foxmail, etc.
-* **MTA (Mail Transfer Agent)**: Refers to an e-mail server program that is used to transmit mail. The MTA is the implementation of SMTP.
+* **MUA (Mail User Agent)**: That is mail clients for users, such as Outlook, Foxmail, etc.
+* **MTA (Mail Transfer Agent)**: Refers to an email server program that is used to transmit mail. The MTA is the implementation of SMTP.
 * **MDA (Mail Delivery Agent)**: When the MTA receives the mail, the MDA is responsible for saving the email to the designated location on the email server, while also performing email filtering and antivirus operations.
 * **MRA (Mail Retrieval Agent)**: The MRA is an implementation of IMAP and POP3, used to interact with MUA and transmit emails to email clients through IMAP or POP3.
 
 ### Three protocols
 
-* **SMTP (Simple Mail Transfer Protocol)**: The standard protocol for sending emails, with a default port of "TCP 25". When encryption function is required, use the "TCP 465" port.
-* **IMAP (Internet Mail Access Protocol)**: Used to receive emails from the email server, the default port is 143. When encryption function is required, use the 993 port.
-* **POP3 (Post Office Protocol - Version 3)**: Used to receive emails from the email server, the default port is 110. When encryption function is required, use the 995 port.
+* **SMTP (Simple Mail Transfer Protocol)**: The standard protocol for sending emails, with a default port of "TCP 25". Use the "TCP 465" port when an encryption function is required. 
+* **IMAP (Internet Mail Access Protocol)**: Used to receive emails from the email server, the default port is 143. Use the 993 port when an encryption function is required.
+* **POP3 (Post Office Protocol - Version 3)**: Used to receive emails from the email server, the default port is 110. Use the 995 port when an encryption function is required.
 
 The difference between IMAP and POP3 is as follows:
 
@@ -68,15 +68,15 @@ For more information about postfix, please refer to these two links:
 
 ![legend01](./email-images/email-system02.jpg)
 
-Postfix determines whether an email sent from a client belongs to the local or external domain. If it belongs to the local domain, the email will be stored in the local domain mailbox. If the email sent belongs to an external domain, it is forwarded to another MTA (the user's identity needs to be verified from the database before forwarding). 
+Postfix determines whether an email sent from a client belongs to the local or external domain. The email will be stored in the local domain mailbox if it belongs to the local domain. If the email sent belongs to an external domain, it is forwarded to another MTA (the user's identity needs to be verified from the database before forwarding). 
 
 ### The process of receiving emails by the client
 
 ![legend02](./email-images/email-system03.jpg)
 
-## Open-source email server
+## Open source email server
 
-A complete email system consists of components that are decentralized and maintained by different individuals or organizations, and the barriers to use for some people are high. As a result, some open-source email servers emerge as the times require, these email servers combine these components to make an out-of-the-box product, for users, all aspects are relatively simple and easy.
+A complete email system consists of components that are decentralized and maintained by different individuals or organizations, and the barriers to use for some people are high. As a result, some open source email servers emerge as the times require, these email servers combine these components to make an out-of-the-box product, for users, all aspects are relatively simple and easy.
 
 * [iredmail](https://www.iredmail.com/index.html)
 * [Zimbra Email Server](https://www.zimbra.com/)


### PR DESCRIPTION
* some sentence rewording changes
* use "email" consistently (was e-mail and email) is now "email"
* use "open source" instead of "open-source" ... the rule is to use open-source only when it is an adjective and that it should never be used as an adjective.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

