### PR TITLE
Update 02-advanced.md - debug module

### DIFF
--- a/docs/books/learning_ansible/02-advanced.md
+++ b/docs/books/learning_ansible/02-advanced.md
@@ -116,7 +116,7 @@ To display a variable, you have to activate the `debug` module as follows:
 
 ```
 - ansible.builtin.debug:
-    var: "{{ service['debian'] }}"
+    var: service['debian']
 ```
 
 You can also use the variable inside a text:


### PR DESCRIPTION
The var attribute in debug module doesnt require "{{ }}" as it runs in Jinja2 context and has an implicit {{ }} wrapping. Removed the wrapping "{{ }}" as it will throw 'template error while templating string'.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

