### PR TITLE
# fix URL

### DIFF
--- a/docs/books/admin_guide/15-three-swordsmen.md
+++ b/docs/books/admin_guide/15-three-swordsmen.md
@@ -1794,13 +1794,13 @@ ID      Name
     By default, `awk` uses newline characters to distinguish each line record
 
     ```bash
-    Shell > echo -e "https://google.com/books/index.html\ntitle//tcp"
-    https://google.com/books/index.html
+    Shell > echo -e "https://example.com/books/index.html\ntitle//tcp"
+    https://example.com/books/index.html
     title//tcp
 
-    Shell > echo -e "https://google.com/books/index.html\ntitle//tcp" | awk 'BEGIN{RS="\/\/";ORS="%%"}{print $0}'
+    Shell > echo -e "https://example.com/books/index.html\ntitle//tcp" | awk 'BEGIN{RS="\/\/";ORS="%%"}{print $0}'
     awk: cmd. line:1: warning: escape sequence `\/' treated as plain `/'
-    https:%%google.com/books/index.html
+    https:%%example.com/books/index.html
     title%%tcp
     %%             ← Why? Because "print"
     ```


### PR DESCRIPTION
* The URL checker used in github does not like the example code using google.com as the URL, because the URL does not exist. "example.com" is already in the list of skipped (not checked) URLs, PLUS the code block still executes and returns the same results as before, so "example.com" has been substituted for "google.com"

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

