### PR TITLE
`torsocks.md`: Fix grammar in "to run"

### DIFF
--- a/docs/gemstones/torsocks.md
+++ b/docs/gemstones/torsocks.md
@@ -17,7 +17,7 @@ dnf -y install tor torsocks
 systemctl enable --now tor
 ```
 
-The common options of the `torsocks` command follow and, under normal circumstances, require nothing additional. The options come before the application runs (e.g., `curl`):
+The common options of the `torsocks` command follow and, under normal circumstances, require nothing additional. The options come before the application to run (e.g., `curl`):
 
 |Options|Description|
 |---|---|


### PR DESCRIPTION
While I appreciate the work @gannazhyrnova did in #1838, one line added a grammar error. This PR fixes that.

#### Author checklist (Completed by original Author)
- [X] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [X] If applicable, steps and instructions have been tested to work
- [X] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

