### PR TITLE
Changed tab for gshadow tip

### DIFF
--- a/docs/books/admin_guide/06-users.md
+++ b/docs/books/admin_guide/06-users.md
@@ -225,7 +225,7 @@ GroupP:x:516:patrick
 
 !!! Note
 
-   Each line in the `/etc/group` file corresponds to a group. The primary user info is stored in `/etc/passwd`.
+    Each line in the `/etc/group` file corresponds to a group. The primary user info is stored in `/etc/passwd`.
 
 ### `/etc/gshadow` file
 


### PR DESCRIPTION
It looks like there may have been a missing space causing the line to not be nested in the tip

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

