### PR TITLE
Docker allow non-root user to manage docker

### DIFF
--- a/docs/gemstones/containers/docker.md
+++ b/docs/gemstones/containers/docker.md
@@ -35,6 +35,24 @@ Use `systemctl` to configure Docker to automatically startup upon reboot and sim
 sudo systemctl --now enable docker
 ```
 
+## Optionally allow a non-root user to manage docker
+
+Add a non-root user to the `docker` group to allow the user to manage `docker` without `sudo`.
+
+This is an optional step, but can be a convenience if you are the main user on the system, or if you want to allow multiple users to manage docker, but do not want to grant them `sudo` permissions.
+
+Type:
+
+```bash
+# Add the current user
+sudo usermod -a -G docker $(whoami)
+
+# Add a specific user
+sudo usermod -a -G docker custom-user
+```
+
+It is required to log out and in again to be assigned the new group. Check with the `id` command to verify that the group has been added.
+
 ### Notes
 
 ```docker


### PR DESCRIPTION
Allow a non-root user to run `docker` commands without having to use `sudo`.
Resolves #2021 

Use cases:

The primary user of the system can manage and interact with docker without having to invoke sudo
Multiple users can be allowed to manage docker without the admin having to grant them sudo privileges.

#### Author checklist (Completed by original Author)
- [X] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [X] If applicable, steps and instructions have been tested to work
- [X] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

