### PR TITLE
Syntax of the undo command was incorrect

### DIFF
--- a/docs/books/admin_guide/05-vi.md
+++ b/docs/books/admin_guide/05-vi.md
@@ -345,11 +345,11 @@ These operations are done in *command* mode.
 
 * Undo the last action:
 
-++u++
+++"u"++
 
 * Undo the actions on the current line:
 
-++U++
+++u++
 
 ### Cancel cancellation
 


### PR DESCRIPTION
* When markdown errors were recently corrected, the undo command was improperly formatted as
```
Undo the last action:

++u++

Undo the actions on the current line:

++U++
```
However neither line is correct. Markdown keyboard commands always assume a capital letter, and must be entered in lower case or in quotes. To get the desired lower-case "u" for the first and capital U for the second, it must be entered as:

```
Undo the last action:

++"u"++

Undo the actions on the current line:

++u++
```

The first will now render in lower-case as expected and the second will render a capital "U."

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

