### PR TITLE
Update lab6-the_file_system.md

### DIFF
--- a/docs/labs/systems_administration_II/lab6-the_file_system.md
+++ b/docs/labs/systems_administration_II/lab6-the_file_system.md
@@ -671,37 +671,20 @@ You'll add the `/dev/loop1` physical volume (PV) that was prepped and created ab
 
     !!! Question
 
-        Using your `vgdisplay` output, note down the changes on your system. What are the new values for "Free PE / Size"?  
-
-#### To remove a LV, VG and PV
-
-This section will step through how to delete the `/dev/loop1` PV that you assigned to the existing `rl` VG in the previous section.
-
-1. Remove the logical volume named scratch2. Type:
+        Using your `vgdisplay` output, note down the changes on your system. What are the new values for "Free PE / Size"?
+     
+4. To remove the new PV (/dev/loop1) from the existing `rl` volume group. Use the `vgreduce` command, type:
 
     ```bash
-    [root@localhost ~]# lvremove -f  /dev/rl/scratch2
-    Logical volume "scratch2" successfully removed.
+    [root@localhost ~]# vgreduce rl /dev/loop1
     ```
 
-2. Remove the scratch3 logical volume, by running:
+    **OUTPUT**
 
     ```bash
-    [root@localhost ~]# lvremove -f  /dev/rl/scratch3
+    Removed "/dev/loop0" from volume group "rl"
     ```
 
-3. With the relevant volumes now removed, you can now reduce the size of the `rl` VG to make it consistent. Type:
-
-    ```bash
-    [root@localhost ~]# vgreduce --removemissing  rl
-    ```
-
-4. Remove any LVM labels from the `/dev/loop1` PV. Type:
-
-    ```bash
-    [root@localhost ~]# pvremove /dev/loop1
-    Labels on physical volume "/dev/loop1" successfully wiped.
-    ```
 
 #### To create a new volume group
 
@@ -788,6 +771,36 @@ With the additional free space we have been able to add to the `rl` volume group
     ```
 
 5. Use the `lvdisplay` command again to view the new LV.
+
+#### To remove a LV, VG and PV
+
+This section will step through how to delete the `/dev/loop1` PV that you assigned to the existing `rl` VG in the previous section.
+
+1. Remove the logical volume named scratch2. Type:
+
+    ```bash
+    [root@localhost ~]# lvremove -f  /dev/rl/scratch2
+    Logical volume "scratch2" successfully removed.
+    ```
+
+2. Remove the scratch3 logical volume, by running:
+
+    ```bash
+    [root@localhost ~]# lvremove -f  /dev/rl/scratch3
+    ```
+
+3. With the relevant volumes now removed, you can now reduce the size of the `rl` VG to make it consistent. Type:
+
+    ```bash
+    [root@localhost ~]# vgreduce --removemissing  rl
+    ```
+
+4. Remove any LVM labels from the `/dev/loop1` PV. Type:
+
+    ```bash
+    [root@localhost ~]# pvremove /dev/loop1
+    Labels on physical volume "/dev/loop1" successfully wiped.
+    ```
 
 ## Exercise 2
 
@@ -928,7 +941,7 @@ Here we will walk through the use of some common filesystem utilities that can b
     /usr/sbin/fsck.xfs: XFS file system.  
     ```
 
-## Exercise
+## Exercise 3
 
 The previous exercises walked through preparing a block/storage device for use on a system. After going through all the motions of partitioning, formatting and so on, the final step in making the file system available to users for storing data is known as mounting.
 


### PR DESCRIPTION
Moved the "To remove a LV, VG and PV" section after the "To create a logical volume" section within Exercise 1, this seemingly being placed incorrectly due to the "scratch" variables appearing before they were defined. 

Added a step 4 to the "To assign a physical volume to a volume group" section, undoing the previous action, which will help the user follow into the next section.

Added a number 3 after "## Exercise".

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

