### PR TITLE
Add missing ` in podman.md

### DIFF
--- a/docs/gemstones/containers/podman.md
+++ b/docs/gemstones/containers/podman.md
@@ -42,7 +42,7 @@ As mentioned, you can run Podman containers as `systemd` services. Let us now do
 
 ```bash
 podman ps
-``
+```
 
 You will get a list of running containers:
 


### PR DESCRIPTION
It's a one character fix of a missing ` breaking code formating.
