### PR TITLE
Light editing `active_directory_authentication_with_samba.md`

### DIFF
--- a/docs/guides/security/authentication/active_directory_authentication_with_samba.md
+++ b/docs/guides/security/authentication/active_directory_authentication_with_samba.md
@@ -1,11 +1,9 @@
 ---
 title: Active Directory Authentication with Samba
 author: Neel Chauhan
-contributors: Hayden Younge, Steven Spencer, Sambhav Saggi, Antoine Le Morvan, Krista Burdine, Ganna Zhyrnova
+contributors: Steven Spencer
 tested_with: 9.4
 ---
-
-# Active Directory Authentication
 
 ## Prerequisites
 
@@ -16,7 +14,7 @@ tested_with: 9.4
 
 In most enterprises, Microsoft's Active Directory (AD) is the default authentication system for Windows systems and for external, LDAP-connected services. It allows you to configure users and groups, access control, permissions, auto-mounting, and more.
 
-Now, while connecting Linux to an AD cluster cannot support _all_ of the features mentioned, it can handle users, groups, and access control. It is possible (through some configuration tweaks on the Linux side and some advanced options on the AD side) to distribute SSH keys using AD.
+While connecting Linux to an AD cluster cannot support _all_ of the features mentioned, it can handle users, groups, and access control. It is possible (through some configuration tweaks on the Linux side and some advanced options on the AD side) to distribute SSH keys using AD.
 
 The default way of using Active Directory on Rocky Linux uses SSSD but Samba is a more full-featured alternative. For instance, file sharing can be done with Samba but not SSSD. This guide, however, will just cover configuring authentication against Active Directory using Samba, and will not include any extra configuration on the Windows side.
 
@@ -64,10 +62,9 @@ The first step to joining a Linux system into AD is to discover your AD cluster,
   [user@host ~]$ sudo dnf install samba samba-winbind samba-client
   ```
 
-
 ### Discovery
 
-Now, you should be able to successfully discover your AD server(s) from your Linux host.
+You should now be able to successfully discover your AD server(s) from your Linux host.
 
 ```sh
 [user@host ~]$ realm discover ad.company.local
@@ -85,7 +82,7 @@ ad.company.local
   required-package: samba-common
 ```
 
-This will be discovered using the relevant SRV records stored in your Active Directory DNS service.
+The relevant SRV records stored in your Active Directory DNS service will allow discovery.
 
 ### Joining
 
@@ -110,7 +107,7 @@ If this process succeeds, you should now be able to pull `passwd` information fo
 AD\administrator:*:1450400500:1450400513:Administrator:/home/administrator@ad.company.local:/bin/bash
 ```
 
-!!! Note 
+!!! Note
 
     `getent` get entries from Name Service Switch libraries (NSS). It means that, contrary to `passwd` or `dig` for example, it will query different databases, including `/etc/hosts` for `getent hosts` or from `samba` in the `getent passwd` case.
 
@@ -123,13 +120,13 @@ AD\administrator:*:1450400500:1450400513:Administrator:/home/administrator@ad.co
 | --os-version='8'                                           | Specify the OS version stored in the AD  |
 | -U admin_username                                          | Specify an admin account                 |
 
-### Attempting to Authenticate
+### Attempting to authenticate
 
 Now your users should be able to authenticate to your Linux host against Active Directory.
 
 **On Windows 10:** (which provides its own copy of OpenSSH)
 
-```
+```dos
 C:\Users\John.Doe> ssh -l john.doe@ad.company.local linux.host
 Password for john.doe@ad.company.local:
 
@@ -162,11 +159,11 @@ To make this configuration change take effect, you must restart the `smb` and `w
 [user@host ~]$ sudo systemctl restart smb winbind
 ```
 
-In the same way, if you don't want your home directories to be suffixed by the domain name, you can add those options into your configuration file `/etc/samba/smb.conf`:
+In the same way, if you do not want your home directories suffixed with the domain name, you can add those options into your configuration file `/etc/samba/smb.conf`:
 
-```
+```bash
 [global]
 template homedir = /home/%U
 ```
 
-Don't forget to restart the `smb` and `winbind` services.
+Do not forget to restart the `smb` and `winbind` services.


### PR DESCRIPTION
* When using the "title:" meta, the Level 1 heading for the document will default to the title and and markdown checkers will argue about duplicate Level 1 headings, remove secondary Level 1
* Use sentence style heading capitalization throughout
* remove some passive voice phrasing
* some sentence simplification
* remove some errant line feeds and extra spaces

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

