### PR TITLE
Update librenms_monitoring_server.md - php dnf module variant

### DIFF
--- a/docs/guides/network/librenms_monitoring_server.md
+++ b/docs/guides/network/librenms_monitoring_server.md
@@ -46,10 +46,17 @@ The version of the repository you install will depend on the version of Rocky Li
 dnf install http://rpms.remirepo.net/enterprise/remi-release-9.rpm
 ```
 
+Then set the dnf to use remi packages instead of the regular packages
+
+```bash
+dnf module reset php
+dnf module enable php:8.1
+```
+
 Once both the EPEL and REMI repositories are installed, it is time to install the packages:
 
 ```bash
-dnf install bash-completion cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php81-php-fpm php81-php-cli php81-php-common php81-php-curl php81-php-gd php81-php-json php81-php-mbstring php81-php-process php81-php-snmp php81-php-xml php81-php-zip php81-php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip python3-systemd rrdtool unzip wget
+dnf install bash-completion cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php-fpm php-cli php-common php-curl php-gd php-gmp php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip python3-systemd rrdtool unzip wget
 ```
 
 All of these packages represent some portion of the LibreNMS feature set.


### PR DESCRIPTION
Installing php81 adds php81 as a command and does not replace the classic php command.

Thus in my case the dependency script failed as there is no php command.

in the official librenms documentation for centos 8, they use dnf module to replace the php install with the remi one.

I consider this case similar here.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

