### PR TITLE
Fix formatting accidentally removed `disa_stig_part3.md`

### DIFF
--- a/docs/books/disa_stig/disa_stig_part3.md
+++ b/docs/books/disa_stig/disa_stig_part3.md
@@ -120,9 +120,10 @@ sed -i 's/^\([^#].*\)/# \1/g' /etc/httpd/conf.d/welcome.conf
 **Fix:** None, Fixed by default in Rocky Linux 8  
 
 **(V-214245)** The Apache web server must have Web Distributed Authoring (WebDAV) disabled.
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 sed -i 's/^\([^#].*\)/# \1/g' /etc/httpd/conf.d/welcome.conf
@@ -130,21 +131,21 @@ sed -i 's/^\([^#].*\)/# \1/g' /etc/httpd/conf.d/welcome.conf
 
 **(V-214264)** The Apache web server must be configured to integrate with an organization's security infrastructure.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, forward web server logs to SIEM
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, forward web server logs to SIEM  
 
 **(V-214243)** The Apache web server must have resource mappings set to disable the serving of certain file types.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None,  Fixed by default in Rocky Linux 8
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by default in Rocky Linux 8  
 
 **(V-214240)** The Apache web server must only contain services and functions necessary for operation.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 dnf remove httpd-manual
@@ -152,15 +153,15 @@ dnf remove httpd-manual
 
 **(V-214238)** Expansion modules must be fully reviewed, tested, and signed before they can exist on a production Apache web server.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, disable all modules not required for the application
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, disable all modules not required for the application  
 
 **(V-214268)** Cookies exchanged between the Apache web server and the client, such as session cookies, must have cookie properties set to prohibit client-side scripts from reading the cookie data.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 dnf install mod_session
@@ -169,51 +170,51 @@ echo “SessionCookieName session path=/; HttpOnly; Secure;” >>  /etc/httpd/co
 
 **(V-214269)** The Apache web server must remove all export ciphers to protect the confidentiality and integrity of transmitted information.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None, Fixed by default in Rocky Linux 8 DISA STIG security Profile
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by default in Rocky Linux 8 DISA STIG security Profile  
 
 **(V-214260)** The Apache web server must be configured to immediately disconnect or disable remote access to the hosted applications.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, this is a procedure to stop the web server
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, this is a procedure to stop the web server  
 
 **(V-214249)** The Apache web server must separate the hosted applications from hosted Apache web server management functionality.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, this is related to the web applications rather than the server
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, this is related to the web applications rather than the server  
 
 **(V-214246)** The Apache web server must be configured to use a specified IP address and port.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, the web server should be configured to only listen on a specific IP / port
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, the web server should be configured to only listen on a specific IP / port  
 
 **(V-214247)** Apache web server accounts accessing the directory tree, the shell, or other operating system functions and utilities must only be administrative accounts.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, all files, and directories served by the web server need to be owned by administrative users, and not the web server user.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, all files, and directories served by the web server need to be owned by administrative users, and not the web server user.  
 
 **(V-214244)** The Apache web server must allow the mappings to unused and vulnerable scripts to be removed.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, any cgi-bin or other Script/ScriptAlias mappings that are not used must be removed
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, any cgi-bin or other Script/ScriptAlias mappings that are not used must be removed  
 
 **(V-214263)** The Apache web server must not impede the ability to write specified log record content to an audit log server.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Work with the SIEM administrator to allow the ability to write specified log record content to an audit log server.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Work with the SIEM administrator to allow the ability to write specified log record content to an audit log server.  
 
 **(V-214228)** The Apache web server must limit the number of allowed simultaneous session requests.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “MaxKeepAliveRequests 100” > /etc/httpd/conf.d/disa-apache-stig.conf
@@ -221,9 +222,9 @@ echo “MaxKeepAliveRequests 100” > /etc/httpd/conf.d/disa-apache-stig.conf
 
 **(V-214229)** The Apache web server must perform server-side session management.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 sed -i “s/^#LoadModule usertrack_module/LoadModule usertrack_module/g” /etc/httpd/conf.modules.d/00-optional.conf
@@ -231,15 +232,15 @@ sed -i “s/^#LoadModule usertrack_module/LoadModule usertrack_module/g” /etc/
 
 **(V-214266)** The Apache web server must prohibit or restrict the use of nonsecure or unnecessary ports, protocols, modules, and/or services.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Ensure the website enforces the use of IANA well-known ports for HTTP and HTTPS.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Ensure the website enforces the use of IANA well-known ports for HTTP and HTTPS.  
 
 **(V-214241)** The Apache web server must not be a proxy server.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 sed -i "s/proxy_module/#proxy_module/g" /etc/httpd/conf.modules.d/00-proxy.conf
@@ -252,70 +253,71 @@ sed -i "s/proxy_connect_module/#proxy_connect_module/g" /etc/httpd/conf.modules.
 
 **(V-214265)** The Apache web server must generate log records that can be mapped to Coordinated Universal Time (UTC)** or Greenwich Mean Time (GMT) which are stamped at a minimum granularity of one second.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None, Fixed by default in Rocky Linux 8
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by default in Rocky Linux 8  
 
 **(V-214256)** Warning and error messages displayed to clients must be modified to minimize the identity of the Apache web server, patches, loaded modules, and directory paths.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** Use the "ErrorDocument" directive to enable custom error pages for 4xx or 5xx HTTP status codes.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** Use the "ErrorDocument" directive to enable custom error pages for 4xx or 5xx HTTP status codes.  
 
 **(V-214237)** The log data and records from the Apache web server must be backed up onto a different system or media.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, document the web server backup procedures
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, document the web server backup procedures  
 
 **(V-214236)** The log information from the Apache web server must be protected from unauthorized modification or deletion.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, document the web server backup procedures
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, document the web server backup procedures  
 
 **(V-214261)** Non-privileged accounts on the hosting system must only access Apache web server security-relevant information and functions through a distinct administrative account.
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None,  Restrict access to the web administration tool to only the System Administrator, Web Manager, or the Web Manager designees.
+
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Restrict access to the web administration tool to only the System Administrator, Web Manager, or the Web Manager designees.  
 
 **(V-214235)** The Apache web server log files must only be accessible by privileged users.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, To protect the integrity of the data that is being captured in the log files, ensure that only the members of the Auditors group, Administrators, and the user assigned to run the web server software is granted permissions to read the log files.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, To protect the integrity of the data that is being captured in the log files, ensure that only the members of the Auditors group, Administrators, and the user assigned to run the web server software is granted permissions to read the log files.  
 
 **(V-214234)** The Apache web server must use a logging mechanism that is configured to alert the Information System Security Officer (ISSO) and System Administrator (SA) in the event of a processing failure.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Work with the SIEM administrator to configure an alert when no audit data is received from Apache based on the defined schedule of connections.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Work with the SIEM administrator to configure an alert when no audit data is received from Apache based on the defined schedule of connections.  
 
 **(V-214233)** An Apache web server, behind a load balancer or proxy server, must produce log records containing the client IP information as the source and destination and not the load balancer or proxy IP information with each event.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Access the proxy server through which inbound web traffic is passed and configure settings to pass web traffic to the Apache web server transparently.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Access the proxy server through which inbound web traffic is passed and configure settings to pass web traffic to the Apache web server transparently.  
 
 Refer to <https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html> for additional information on logging options based on your proxy/load balancing setup.
 
 **(V-214231)** The Apache web server must have system logging enabled.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None, Fixed by default in Rocky Linux 8
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by default in Rocky Linux 8  
 
 **(V-214232)** The Apache web server must generate, at a minimum, log records for system startup and shutdown, system access, and system authentication events.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None, Fixed by default in Rocky Linux 8
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by default in Rocky Linux 8  
 
-V-214251 Cookies exchanged between the Apache web server and client, such as session cookies, must have security settings that disallow cookie access outside the originating Apache web server and hosted application.
+**(V-214251)** Cookies exchanged between the Apache web server and client, such as session cookies, must have security settings that disallow cookie access outside the originating Apache web server and hosted application.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “Session On” >>  /etc/httpd/conf.d/disa-apache-stig.conf
@@ -323,9 +325,9 @@ echo “Session On” >>  /etc/httpd/conf.d/disa-apache-stig.conf
 
 **(V-214250)** The Apache web server must invalidate session identifiers upon hosted application user logout or other session termination.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “SessionMaxAge 600” >>  /etc/httpd/conf.d/disa-apache-stig.conf
@@ -333,9 +335,9 @@ echo “SessionMaxAge 600” >>  /etc/httpd/conf.d/disa-apache-stig.conf
 
 **(V-214252)** The Apache web server must generate a session ID long enough that it cannot be guessed through brute force.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “SessionCryptoCipher aes256” >>  /etc/httpd/conf.d/disa-apache-stig.conf
@@ -343,9 +345,9 @@ echo “SessionCryptoCipher aes256” >>  /etc/httpd/conf.d/disa-apache-stig.con
 
 **(V-214255)** The Apache web server must be tuned to handle the operational requirements of the hosted application.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “Timeout 10” >>  /etc/httpd/conf.d/disa-apache-stig.conf
@@ -353,15 +355,15 @@ echo “Timeout 10” >>  /etc/httpd/conf.d/disa-apache-stig.conf
 
 **(V-214254)** The Apache web server must be built to fail to a known safe state if system initialization fails, shutdown fails, or aborts fail.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Prepare documentation for disaster recovery methods for the Apache 2.4 web server in the event of the necessity for rollback.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Prepare documentation for disaster recovery methods for the Apache 2.4 web server in the event of the necessity for rollback.  
 
 **(V-214257)** Debugging and trace information used to diagnose the Apache web server must be disabled.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “TraceEnable Off” >>  /etc/httpd/conf.d/disa-apache-stig.conf
@@ -369,9 +371,9 @@ echo “TraceEnable Off” >>  /etc/httpd/conf.d/disa-apache-stig.conf
 
 **(V-214230)** The Apache web server must use cryptography to protect the integrity of remote sessions.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 sed -i "s/^#SSLProtocol.*/SSLProtocol -ALL +TLSv1.2/g" /etc/httpd/conf.d/ssl.conf
@@ -379,9 +381,9 @@ sed -i "s/^#SSLProtocol.*/SSLProtocol -ALL +TLSv1.2/g" /etc/httpd/conf.d/ssl.con
 
 **(V-214258)** The Apache web server must set an inactive timeout for sessions.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  
 
 ```bash
 echo “RequestReadTimeout 120” >> /etc/httpd/conf.d/disa-stig-apache.conf
@@ -389,28 +391,29 @@ echo “RequestReadTimeout 120” >> /etc/httpd/conf.d/disa-stig-apache.conf
 
 **(V-214270)** The Apache web server must install security-relevant software updates within the configured time period directed by an authoritative source (e.g., IAVM, CTOs, DTMs, and STIGs).
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Install the current version of the web server software and maintain appropriate service packs and patches.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Install the current version of the web server software and maintain appropriate service packs and patches.  
 
 **(V-214239)** The Apache web server must not perform user management for hosted applications.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:**  None, Fixed by default in Rocky Linux 8
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:**  None, Fixed by default in Rocky Linux 8  
 
 **(V-214274)** The Apache web server htpasswd files (if present) must reflect proper ownership and permissions.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Ensure the SA or Web Manager account owns the "htpasswd" file.  Ensure permissions are set to "550".
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Ensure the SA or Web Manager account owns the "htpasswd" file. Ensure permissions are set to "550".  
 
 **(V-214259)** The Apache web server must restrict inbound connections from nonsecure zones.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** None, Configure the "http.conf" file to include restrictions.
- Example:
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** None, Configure the "http.conf" file to include restrictions.  
+
+Example:
 
 ```bash
 Require not ip 192.168.205
@@ -419,23 +422,22 @@ Require not host phishers.example.com
 
 **(V-214267)** The Apache web server must be protected from being stopped by a non-privileged user.
 
-**Severity:** Cat II Medium
-**Type:** Technical
-**Fix:** None, Fixed by Rocky Linux 8 by default
+**Severity:** Cat II Medium  
+**Type:** Technical  
+**Fix:** None, Fixed by Rocky Linux 8 by default  
 
 **(V-214262)** The Apache web server must use a logging mechanism that is configured to allocate log record storage capacity large enough to accommodate the logging requirements of the Apache web server.
 
-**Severity:** Cat II Medium
-**Type:** Operational
-**Fix:** none, Work with the SIEM administrator to determine if the SIEM is configured to allocate log record storage capacity large enough to accommodate the logging requirements of the Apache web server.
+**Severity:** Cat II Medium  
+**Type:** Operational  
+**Fix:** none, Work with the SIEM administrator to determine if the SIEM is configured to allocate log record storage capacity large enough to accommodate the logging requirements of the Apache web server.  
 
 **(V-214272)** The Apache web server must be configured in accordance with the security configuration settings based on DoD security configuration or implementation guidance, including STIGs, NSA configuration guides, CTOs, and DTMs.
 
-**Severity:** Cat III Low
-**Type:** Operational
-**Fix:**  None
+**Severity:** Cat III Low  
+**Type:** Operational  
+**Fix:**  None  
 
 ## About The Author
 
-Scott Shinn is the CTO for Atomicorp, and part of the Rocky Linux Security team. He has been involved with federal information systems at the White House, Department of Defense, and Intelligence Community since 1995. Part of that was creating STIG’s and the requirement th
-at you use them and I am so very sorry about that.
+Scott Shinn is the CTO for Atomicorp, and part of the Rocky Linux Security team. He has been involved with federal information systems at the White House, Department of Defense, and Intelligence Community since 1995. Part of that was creating STIG’s and the requirement that you use them and I am so very sorry about that.


### PR DESCRIPTION
* a contributor fixing markdown errors in the past, stripped out the double-space markdown that creates a blank line, this caused this file to be badly formatted.
* reinserted the double-space at end of line for those lines needing it

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

