### PR TITLE
Podman: Correct `Quadlet` install mechanism

### DIFF
--- a/docs/gemstones/containers/podman.md
+++ b/docs/gemstones/containers/podman.md
@@ -86,12 +86,7 @@ To automatically run the container upon system start or user login, you can add 
 WantedBy=default.target
 ```
 
-Then let the generator run again and enable your service:
-
-```bash
-systemctl --user daemon-reload;
-systemctl --user enable nextcloud.service;
-```
+As the generated service files are considered transient, they cannot be enabled by systemd. To mitigate this, the generator manually applies installs during generation. This effectively also enables those services files.
 
 Other file types are supported: pod, volume, network, image, and kube. [Pods](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#pod-units-pod), for instance, can be used to group containers – the generated systemd services and their dependencies (create the pod before the containers) are automatically managed by systemd.
 

--- a/docs/guides/containers/podman_guide.md
+++ b/docs/guides/containers/podman_guide.md
@@ -163,12 +163,7 @@ To automatically run the container upon system start or user login, you can add 
 WantedBy=default.target
 ```
 
-Then let the generator run again and enable your service:
-
-```bash
-systemctl --user daemon-reload;
-systemctl --user enable nextcloud.service;
-```
+As the generated service files are considered transient, they cannot be enabled by systemd. To mitigate this, the generator manually applies installs during generation. This effectively also enables those services files.
 
 Other file types are supported: pod, volume, network, image, and kube. [Pods](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#pod-units-pod), for instance, can be used to group containers – the generated systemd services and their dependencies (create the pod before the containers) are automatically managed by systemd.
 


### PR DESCRIPTION
Quadlet services do not support enabling by `systemd enable`. Remove the wrong section and replace it with hint about the generator procedure.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

