### PR TITLE
fix: wireguard_vpn.md, spelling, punctuation

### DIFF
--- a/docs/guides/security/wireguard_vpn.md
+++ b/docs/guides/security/wireguard_vpn.md
@@ -21,7 +21,7 @@ The following are minimum requirements for this procedure:
 
 ## Installing WireGuard
 
-Install Extra Packages for Enterprise Linux(EPEL):
+Install Extra Packages for Enterprise Linux (EPEL):
 
 ```bash
 sudo dnf install epel-release
@@ -214,7 +214,7 @@ The peer's configuration file now includes a rule, `PersistentKeepalive = 25`. T
 Output the peer's public key and copy it:
 
 ```bash
-sudo cat /etc/wiregaurd/publickey
+sudo cat /etc/wireguard/publickey
 ```
 
 On the server, run the following command, replacing `peer_publickey` with the peers public key:


### PR DESCRIPTION
- sudo cat /etc/**wireguard**/publickey
- ... Enterprise **Linux (EPEL):**

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

