### PR TITLE
Git ignore pattern to exclude cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /build_pdf/pdf/*.pdf
+
+.cache


### PR DESCRIPTION
Added a Git ignore pattern to exclude cache. (Cache is generated by some of the local development site methods)