### PR TITLE
Link to hpe document is broken

### DIFF
--- a/docs/guides/hardware/hpe_amsd.md
+++ b/docs/guides/hardware/hpe_amsd.md
@@ -11,7 +11,13 @@ tags:
 
 ## Introduction
 
-HPE ProLiant servers have a companion software called Agentless Management Service which [according to HPE](https://techlibrary.hpe.com/docs/iss/EL8000t/setup_install/GUID-1CF69B20-790A-4EDC-A162-9D64572ED9E8.html) "uses out-of-band communication for increased security and stability." In addition, "with Agentless Management, health monitoring, and alerting is built into the system and begins working the moment auxiliary power is connected to [your server]".
+HPE ProLiant servers have a companion software called Agentless Management Service which according to HPE:
+
+> uses out-of-band communication for increased security and stability.
+
+In addition: 
+
+> with Agentless Management, health monitoring, and alerting is built into the system and begins working the moment auxiliary power is connected to your server.
 
 This is used, for example, to reduce fan speeds on an HPE ProLiant ML110 Gen11 in the author's home lab.
 


### PR DESCRIPTION
* HPE moved everything to another URL, and I could find no direct URL replacement
* The URL wasn't providing anything but a reference back to an HPE tech article
* left the quotes in tact, and removed the URL
* used block quotes for the quotes from HPE

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

