### PR TITLE
Fix typos in package list (installing_nvidia_gpu_drivers.md)

### DIFF
--- a/docs/desktop/display/installing_nvidia_gpu_drivers.md
+++ b/docs/desktop/display/installing_nvidia_gpu_drivers.md
@@ -70,7 +70,7 @@ sudo dnf config-manager --add-repo http://developer.download.nvidia.com/compute/
 Next, install a set of packages necessary for building and installing kernel modules:
 
 ```bash
-sudo dnf install kernel-headers-$(uname -r) kernel-devel-$(uname -r) tar bzip2 make automake gcc gcc-c++ pciutils elfutils-libelf-devel libglvnd-opengl libglvnd-glx libglv-devel acpid pkgconfig dkms -y
+sudo dnf install kernel-headers-$(uname -r) kernel-devel-$(uname -r) tar bzip2 make automake gcc gcc-c++ pciutils elfutils-libelf-devel libglvnd-opengl libglvnd-glx libglvnd-devel acpid pkgconf dkms -y
 ```
 
 Install the latest NVIDIA driver module for your system:


### PR DESCRIPTION
Fixed typos in list of necessary packages for building and installing kernel modules:

* `libglvnd-devel` instead of `libglv-devel` (does not exist)
* `pkgconf` instead of `pkgconfig` (or should it be `pkg-config`?)

The first item causes an error `Error: Unable to find a match: libglv-devel`. Given that the list includes `libglvnd-opengl libglvnd-glx` I assume that `libglvnd-devel` is the right replacement. However, I am a Rocky Linux newbie, so I am not sure about this.

It seems the second item is still correctly resolved (maybe there is some kind of alias name for this package?). However, `pkgconfig` seems not to be the correct name because I cannot find it with `dnf search`.

The fixed package list does work fine with a fresh install of Rocky Linux 9.4 and allowed me to properly install the NVIDIA drivers.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

