### PR TITLE
Because of failing URLs

### DIFF
--- a/docs/books/web_services/052-load-balancer-proxies-varnish.md
+++ b/docs/books/web_services/052-load-balancer-proxies-varnish.md
@@ -486,7 +486,7 @@ varnishadm
 varnish> ban req.url ~ ".css$"
 200
 
-varnish> ban req.http.host == www.example.com
+varnish> ban req.http.host == example.com
 200
 
 varnish> ban req.http.host ~ .
@@ -496,7 +496,7 @@ varnish> ban req.http.host ~ .
 via an HTTP PURGE request:
 
 ```bash
-curl -X PURGE http://www.example.org/foo.txt
+curl -X PURGE http://example.org/foo.txt
 ```
 
 Configuring Varnish to accept this request is done with:

--- a/docs/books/web_services/053-load-balancer-proxies-squid.md
+++ b/docs/books/web_services/053-load-balancer-proxies-squid.md
@@ -519,12 +519,12 @@ sudo dnf clean all
 sudo dnf update
 ```
 
-Verify on your terminal that the `dnf` connection uses your proxy to download its update:
+Verify on your terminal that the `dnf` connection uses your proxy to download its update. Note that the "URL of repository" in the line that follows will be replaced with the actual mirror URL.:
 
 ```bash
-1723793986.725     20 192.168.1.10 TCP_MISS/200 5238 GET http://rocky.reloumirrors.net/9.4/extras/x86_64/os/repodata/7d78a729-8e9a-4066-96d4-ab8ed8f06ee8-FILELISTS.xml.gz - HIER_DIRECT/193.106.119.144 application/x-gzip
+1723793986.725     20 192.168.1.10 TCP_MISS/200 5238 GET "URL of repository"/9.4/extras/x86_64/os/repodata/7d78a729-8e9a-4066-96d4-ab8ed8f06ee8-FILELISTS.xml.gz - HIER_DIRECT/193.106.119.144 application/x-gzip
 ...
-1723794176.255      1 192.168.1.10 TCP_HIT/200 655447 GET http://miroir.univ-lorraine.fr/rocky/9.4/AppStream/x86_64/os/repodata/1af312c9-7139-43ed-8761-90ba3cd55461-UPDATEINFO.xml.gz - HIER_NONE/- application/x-gzip
+1723794176.255      1 192.168.1.10 TCP_HIT/200 655447 GET "URL of repository"/9.4/AppStream/x86_64/os/repodata/1af312c9-7139-43ed-8761-90ba3cd55461-UPDATEINFO.xml.gz - HIER_NONE/- application/x-gzip
 ```
 
 In this example, you can see one connection with a TCP_MISS (not present in the cache) and another with TCP_HIT (use the cache to answer the client).


### PR DESCRIPTION
* changed the content to "URL of repository" in quotes for both failing URLs

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

