### PR TITLE
fix: remove sudo command

### DIFF
--- a/docs/gemstones/containers/docker.md
+++ b/docs/gemstones/containers/docker.md
@@ -16,7 +16,7 @@ The Docker Engine can run native Docker-style container workloads on Rocky Linux
 Use the `dnf` utility to add the Docker repository to your Rocky Linux server. Type:
 
 ```bash
-sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 ```
 
 ## Install the needed packages
@@ -24,7 +24,7 @@ sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker
 Install the latest version of Docker Engine, `containerd`, and Docker Compose, by running:
 
 ```bash
-sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
 
 ## Start and enable Docker (`dockerd`)
@@ -32,7 +32,7 @@ sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 Use `systemctl` to configure Docker to automatically startup upon reboot and simultaneously start it now. Type:
 
 ```bash
-sudo systemctl --now enable docker
+systemctl --now enable docker
 ```
 
 ## Optionally allow a non-root user to manage docker
@@ -45,10 +45,10 @@ Type:
 
 ```bash
 # Add the current user
-sudo usermod -a -G docker $(whoami)
+usermod -a -G docker $(whoami)
 
 # Add a specific user
-sudo usermod -a -G docker custom-user
+usermod -a -G docker custom-user
 ```
 
 To be assigned the new group, you must log out and in again. Check with the `id` command to verify that the group has been added.


### PR DESCRIPTION
Hello,

I suggest to remove all sudo commands from the `docker` install documentation, the sudo is useless and not used in the podman documentation.

In my opinion, it's a bit obvious to be root to run package installation and group configuration, and sometimes, sudo may not be installed on the server :)


#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

