### PR TITLE
Crowdin will not honor fixing anchors

### DIFF
--- a/docs/books/sed_awk_grep/4_awk_command.md
+++ b/docs/books/sed_awk_grep/4_awk_command.md
@@ -1798,7 +1798,7 @@ Like most programming languages, `awk` also supports arrays, which are divided i
 | command \| getline [var]  | Assign the result to "$0" or the variable "var" |
 | next                      | Stop the current input record and perform the following actions|
 | print                     | Print the result |
-| printf                    | See [here](#printf-commands)|
+| printf                    | See the section for that command in this document|
 | system(cmd-line)          | Execute the command and return the status code. 0 indicates that the command was executed successfully; non-0 indicates that the execution failed |
 | print ... >> file         | Output redirection |
 | print ... \| command      | Print the output and use it as input to the command |

--- a/docs/guides/automation/cron_jobs_howto.md
+++ b/docs/guides/automation/cron_jobs_howto.md
@@ -85,7 +85,7 @@ Provided you are good with just letting the system auto-run your scripts, and al
 
 ### Create your own `cron`
 
-If the automated, randomized times do not work well in [For Workstations above](#for-workstations), and the scheduled times in the [For Servers above](#for-servers), you can create your own. In this example, the assumption is you are doing this as the root user. [see Assumptions](#assumptions) To do this, type the following:
+If the automated, randomized times do not work well for workstations, or the scheduled times for servers, you can create your own. In this example, the assumption is you are doing this as the root user. To do this, type the following:
 
 `crontab -e`
 

--- a/docs/guides/contribute/localdocs/rockydocs_webdev_v2.md
+++ b/docs/guides/contribute/localdocs/rockydocs_webdev_v2.md
@@ -13,9 +13,33 @@ Running a local copy of the documentation website might be useful in the followi
 - You are interested in learning about and contributing to the web development aspects of the docs.rockylinux.org website
 - You are an author and you'd like to see how your documents will render/look on the docs website before contributing them
 
+## Setup the prerequisites
+
+Install and setup Podman and other tools by running:
+
+```bash
+sudo dnf -y install podman podman-docker git
+
+sudo systemctl enable --now  podman.socket
+```
+
+Install docker-compose and make it executable. Type:
+
+```bash
+curl -SL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+
+chmod 755 /usr/local/bin/docker-compose
+```
+
+Fix permissions on docker socket. Type:
+
+```bash
+sudo chmod 666 /var/run/docker.sock
+```
+
 ## Create the content environment
 
-1. Ensure that the prerequisites are satisfied. If not please skip to the "[Setup the prerequisites](#setup-the-prerequisites)" section and then return here.
+1. Ensure that the prerequisites are satisfied.
 
 2. Change the current working directory on your local system to a folder where you intend to do your writing.
   We will refer to this directory as
@@ -119,31 +143,7 @@ If you have a firewall running on your Rocky Linux system, ensure that port 8001
 
   <http://SERVER_IP:8001>
 
-## Setup the prerequisites
-
-Install and setup Podman and other tools by running:
-
-```bash
-sudo dnf -y install podman podman-docker git
-
-sudo systemctl enable --now  podman.socket
-```
-
-Install docker-compose and make it executable. Type:
-
-```bash
-curl -SL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-
-chmod 755 /usr/local/bin/docker-compose
-```
-
-Fix permissions on docker socket. Type:
-
-```bash
-sudo chmod 666 /var/run/docker.sock
-```
-
-### Notes
+## Notes
 
 - The instructions in this guide are **NOT** a prerequisite for Rocky documentation authors or content contributors
 - The entire environment runs in a Podman container and so you will need Podman properly setup on your local machine

--- a/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
+++ b/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
@@ -282,7 +282,9 @@ This will enable login for your virtual users defined in `vsftpd-virtual-user.db
 
 Each virtual user has a configuration file, specifying their own "local_root" directory. Ownership of this local root is the user "vsftpd" and the group "nogroup".
 
-Refer to [Setting Up Virtual Users section above.](#setting-up-virtual-users) To change the ownership for the directory, enter this at the command line:
+(Refer to "Setting Up Virtual Users" section)
+
+To change the ownership for the directory, enter this at the command line:
 
 ```bash
 chown vsftpd.nogroup /var/www/sub-domains/whatever_the_domain_name_is/html

--- a/docs/guides/web/apache-sites-enabled.md
+++ b/docs/guides/web/apache-sites-enabled.md
@@ -86,7 +86,7 @@ Say you have a website that loads a wiki. You will need a configuration file, wh
 
 If you want to serve the website with SSL/TLS (and face it, in most cases you do), you need to add another section to that file to enable port 443.
 
-You can examine that below in the [Configuration `https` using An SSL/TLS certificate](#configuration-https-using-an-ssltls-certificate) section.
+You can examine that below in the "Configuration `https` using An SSL/TLS certificate" section.
 
 You first need to create this configuration file in *sites-available*:
 

--- a/docs/guides/web/apache_hardened_webserver/index.md
+++ b/docs/guides/web/apache_hardened_webserver/index.md
@@ -26,14 +26,13 @@ Whether you are hosting many websites for customers or a single important websit
 
 With many web sites uploaded by your customers, one of them will probably upload a Content Management System (CMS) with the possibility of vulnerabilities. Most customers focus on ease of use, not security, and what happens is that updating their own CMS becomes a process that falls out of their priority list altogether.
 
-
 While notifying customers of vulnerabilities in their CMS is possible for a company with a large IT staff, this might not be realistic for a small IT team. The best defense is a hardened web server.
 
 Web server hardening can take many forms, including any or all of the tools here and possibly others not defined.
 
 You might use a couple of these tools and not the others. For clarity and readability this document splits into separate documents for each tool. The exception will be the packet-based firewall (`firewalld`) in this main document.
 
-* A good packet filter firewall based on ports (iptables, firewalld, or hardware firewall - using `firewalld` for our examples) [`firewalld` procedure](#configuring-firewalld)
+* A good packet filter firewall based on ports (iptables, firewalld, or hardware firewall - using `firewalld` for our examples)  See the `firewalld` procedure later in this document.
 * A Host-based Intrusion Detection System (HIDS), in this case _ossec-hids_ [Apache Hardened Web Server - ossec-hids](ossec-hids.md)
 * A Web-based Application Firewall (WAF), with `mod_security` rules [Apache Hardened Web Server - mod_security](modsecurity.md)
 * Rootkit Hunter (`rkhunter`): A scan tool that checks against Linux malware [Apache Hardened Web Server - rkhunter](rkhunter.md)


### PR DESCRIPTION
* since Crowdin will not honor anchors being fixed outside of the system, they must be removed from the source and the user will have to be directed in another way.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

