### PR TITLE
fix: firewalld-beginners.md wrong apostrophe

### DIFF
--- a/docs/guides/security/firewalld-beginners.md
+++ b/docs/guides/security/firewalld-beginners.md
@@ -49,7 +49,7 @@ You'll need:
 systemctl enable --now firewalld
 ```
 
-The `--now` flag starts the service as soon as it is enabled and let's you skip the `systemctl start firewalld` step.
+The `--now` flag starts the service as soon as it is enabled and lets you skip the `systemctl start firewalld` step.
 
 As with all services on Rocky Linux, you can check if the firewall is running with:
 


### PR DESCRIPTION
- the flag starts the service ... and **lets** you skip ...
see:
https://www.merriam-webster.com/dictionary/let%27s
vs
https://www.merriam-webster.com/dictionary/lets

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

