### PR TITLE
Fix typo in my updated part of rdp-server.md

### DIFF
--- a/docs/desktop/gnome/rdp-server.md
+++ b/docs/desktop/gnome/rdp-server.md
@@ -34,7 +34,7 @@ You need an RDP server to make your Rocky Linux desktop-accessible remotely. For
 
 !!! info
 
-    The xrdp package is in [EPEL repository](https://wiki.rockylinux.org/rocky/repo/#community-approved-repositories), which provides rebuilds of Fedora packages for every supported Enterprise Linux. If you haven't enabled it, use the following commands to do so. You [should also enable CRB](https://wiki.rockylinux.org/rocky/repo/#notes-on-epel) (called "PowerTools in Rocky Linux 8) before adding EPEL repository.
+    The xrdp package is in [EPEL repository](https://wiki.rockylinux.org/rocky/repo/#community-approved-repositories), which provides rebuilds of Fedora packages for every supported Enterprise Linux. If you haven't enabled it, use the following commands to do so. You [should also enable CRB](https://wiki.rockylinux.org/rocky/repo/#notes-on-epel) (called 'PowerTools' in Rocky Linux 8) before adding EPEL repository.
 
     In Rocky Linux 8, use these commands to add EPEL repository:
 
@@ -50,7 +50,7 @@ You need an RDP server to make your Rocky Linux desktop-accessible remotely. For
     sudo dnf install epel-release
     ```
 
-After adding EPEL repository (or if you have already added it), use the following command to install xrdp.
+After adding EPEL repository (or if you have already added it), use the following command to install xrdp:
 
 ```bash
 sudo dnf install xrdp


### PR DESCRIPTION
Fix typo: add missing quote mark

Sorry for submitting a patch that included a typo. I have pasted my part into MS Word to check for typos, but the unmatched quote mark was overlooked.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

