### PR TITLE
Corrected configuration file reference

### DIFF
--- a/docs/guides/security/authentication/active_directory_authentication_with_samba.md
+++ b/docs/guides/security/authentication/active_directory_authentication_with_samba.md
@@ -142,7 +142,7 @@ If this succeeds, you have successfully configured Linux to use Active Directory
 
 In a completely default setup, you will need to log in with your AD account by specifying the domain in your username (e.g., `john.doe@ad.company.local`). If this is not the desired behavior and you instead want to be able to omit the default domain name at authentication time you can configure Samba to default to a specific domain.
 
-This is a relatively straightforward process, requiring a configuration tweak in your SSSD configuration file.
+This is a relatively straightforward process, requiring a configuration tweak in your `smb.conf` configuration file.
 
 ```sh
 [user@host ~]$ sudo vi /etc/samba/smb.conf


### PR DESCRIPTION
Corrected a copy-paste error from active_directory_authentication.md, which reference sssd.conf. Here it should be smb.conf.

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

