### PR TITLE
Remove HTML tag </br> in tables (requested by translator)

### DIFF
--- a/docs/books/sed_awk_grep/2_grep_command.md
+++ b/docs/books/sed_awk_grep/2_grep_command.md
@@ -27,17 +27,17 @@ The options are mainly divided into four parts:
 
 match control：
 
-| options                  | description |
-| :---                     | :---        |
-| -E<br/>--extended-regexp | Enable ERE  |
-| -P<br/>--perl-regexp     | Enable PCRE |
-| -G<br/>--basic-regexp    | Enable BRE by default |
-| -e<br/>--regexp=PATTERN  | Pattern matching, multiple -e options can be specified. |
-| -i                       | Ignore case |
-| -w                       | Accurately match the entire word |
-| -f FILE                  | Obtain patterns from FILE, one per line |
-| -x                       | Pattern matching entire line |
-| -v                       | Select content lines that do not match |
+| options                | description                                             |
+|------------------------|---------------------------------------------------------|
+| -E (--extended-regexp) | Enable ERE                                              |
+| -P (--perl-regexp)     | Enable PCRE                                             |
+| -G (--basic-regexp)    | Enable BRE by default                                   |
+| -e (--regexp=PATTERN)  | Pattern matching, multiple -e options can be specified. |
+| -i                     | Ignore case                                             |
+| -w                     | Accurately match the entire word                        |
+| -f FILE                | Obtain patterns from FILE, one per line                 |
+| -x                     | Pattern matching entire line                            |
+| -v                     | Select content lines that do not match                  |
 
 output control:
 

--- a/docs/books/sed_awk_grep/3_sed_command.md
+++ b/docs/books/sed_awk_grep/3_sed_command.md
@@ -30,7 +30,7 @@ sed [OPTION]... {script-only-if-no-other-script} [input-file]...
 | -i    | Modify the original file |
 | -r    | Regular expression |
 
-| Operation command<br/>(sometimes called operation instruction)| description |
+| Operation command  (sometimes called operation instruction)| description |
 | :---:                  | :--- |
 | s/regexp/replacement/  | Replacement string |
 |  p                     | Print the current "pattern space". Often used with the -n option, for example: `cat -n /etc/services \| sed -n '3,5p'` |
@@ -295,7 +295,7 @@ sed [OPTION]... {script-only-if-no-other-script} [input-file]...
 
     | Syntax                               | Syntax description|
     | :---                                 | :---              |
-    | `sed 's/string/replace/g' FILENAME`  | **s**: All lines representing the content of the file. You can also specify the range of lines, for example: `sed '20,200s/netbios/TMP/g' /etc/services`<br/>**g** (Global): If there is no g, This means that when multiple matching strings appear on a single line, only the first matching string will be replaced.<br/> **/**: Delimiter style. You can also specify other styles, for example: `sed '20,200s?netbios?TMP?g' /etc/services` |
+    | `sed 's/string/replace/g' FILENAME`  | **s**: All lines representing the content of the file. You can also specify the range of lines, for example: `sed '20,200s/netbios/TMP/g' /etc/services.  **g** (Global): If there is no g, This means that when multiple matching strings appear on a single line, only the first matching string will be replaced.   **/**: Delimiter style. You can also specify other styles, for example:`sed '20,200s?netbios?TMP?g' /etc/services` |
 
     !!! tip
 

--- a/docs/books/sed_awk_grep/4_awk_command.md
+++ b/docs/books/sed_awk_grep/4_awk_command.md
@@ -96,14 +96,14 @@ The usage of `awk` is - `awk option  'pattern {action}'  FileName`
 **action**: Action instruction
 **{ }**: Group some instructions according to specific patterns
 
-| option | description |
-| :---   | :---        |
-| -f program-file<br/>--file program-file | Reading `awk` program source files from files |
-| -F FS  | Specify the separator for separating fields. The 'FS' here is a built-in variable in `awk`, with default values of spaces or tabs |
-| -v var=value | variable assignment |
-| --posix | Turn on compatibility mode |
-| --dump-variables=[file] | Write global variables in `awk` to a file. If no file is specified, the default file is awkvars.out |
-| --profile=[file] | Write performance analysis data to a specific file. If no file is specified, the default file is awkprof.out |
+| option                               | description                                                                                                                       |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| -f program-file  --file program-file | Reading `awk` program source files from files                                                                                     |
+| -F FS                                | Specify the separator for separating fields. The 'FS' here is a built-in variable in `awk`, with default values of spaces or tabs |
+| -v var=value                         | variable assignment                                                                                                               |
+| --posix                              | Turn on compatibility mode                                                                                                        |
+| --dump-variables=[file]              | Write global variables in `awk` to a file. If no file is specified, the default file is awkvars.out                               |
+| --profile=[file]                     | Write performance analysis data to a specific file. If no file is specified, the default file is awkprof.out                      |
 
 | pattern                | description |
 | :---                   | :---        |
@@ -805,15 +805,21 @@ ID      Name
 
 ## Operator
 
-| Operator  | Description |
-| :---:     | :---        |
-| (...)     | Grouping    |
-| $n        | Field reference |
-| ++<br/>--      | Incremental<br/>Decreasing |
-| +<br/>-<br/>!  | Mathematical plus sign<br/>Mathematical minus sign<br/>Negation|
-| *<br/>/<br/>%  | Mathematical multiplication sign<br/>Mathematical division sign<br/>Modulo operation |
-| in             | Elements in an array |
-| &&<br/>\|\|    | Logic and Operations<br/>Logical OR operation |
+| Operator | Description     |
+|----------|-----------------|
+| (...)    | Grouping        |
+| $n       | Field reference |
+| ++       | Increment       |
+| -- | Decrement             |
+| + | Mathematical plus sign |
+| - | Mathematical minus sign |
+| ! | Negation |
+| * | Mathematical multiplication sign |
+| / | Mathematical division sign |
+| % | Modulo operation |
+| in | Elements in an array |
+| && | Logic and operations |
+| \|\| | Logical OR operation |
 | ?:  |  Abbreviation of conditional expressions |
 | ~   | Another representation of regular expressions |
 | !~  | Reverse Regular Expression |
@@ -1793,7 +1799,7 @@ Like most programming languages, `awk` also supports arrays, which are divided i
 
 | Statement                 | Description |
 | :---                      | :---        |
-| getline                   | Read the next matching row record and assign it to "$0". <br/>The return value is 1: Indicates that relevant row records have been read. <br/>The return value is 0: Indicates that the last line has been read <br/>The return value is negative: Indicates encountering an error |
+| getline                   | Read the next matching row record and assign it to "$0". The return value is 1: Indicates that relevant row records have been read. The return value is 0: Indicates that the last line has been read. The return value is negative: Indicates encountering an error. |
 | getline var               | Read the next matching row record and assign it to the variable "var" |
 | command \| getline [var]  | Assign the result to "$0" or the variable "var" |
 | next                      | Stop the current input record and perform the following actions|


### PR DESCRIPTION
* 2 spaces will not work within a table, in most cases the rows can be further separated to take care of this.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

