### PR TITLE
Discovered a URL error

### DIFF
--- a/docs/guides/contribute/index.md
+++ b/docs/guides/contribute/index.md
@@ -1,0 +1,7 @@
+---
+Title: Introduction
+Author: Steven Spencer
+Contriibutors: 
+---
+
+Here are all the resources on contributing to the documentation for Rocky Linux. Whether you have never contributed anything to a project before, or whether you are an expert contributor, you will find the documents on how to get started here. As always, contact us on our [Mattermost channel](https://chat.rockylinux.org/rocky-linux/channels/documentation) for additional help.


### PR DESCRIPTION
* documents were referencing the "Contribute" section, but were returning 404 because no `index.md` existed
* this is a simple introduction to the contribute section to fix this reference issue.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

