### PR TITLE
Revert "Discovered a URL error"

### DIFF
--- a/docs/guides/contribute/index.md
+++ b/docs/guides/contribute/index.md
@@ -1,7 +1,0 @@
----
-Title: Introduction
-Author: Steven Spencer
-Contriibutors: 
----
-
-Here are all the resources on contributing to the documentation for Rocky Linux. Whether you have never contributed anything to a project before, or whether you are an expert contributor, you will find the documents on how to get started here. As always, contact us on our [Mattermost channel](https://chat.rockylinux.org/rocky-linux/channels/documentation) for additional help.


### PR DESCRIPTION
Reverts rocky-linux/documentation#2686

This should have been loading the README.md as it does locally. Not sure why things changed, but I'm deleting my added index.md.