### PR TITLE
enable crb packet source for ninja-build

### DIFF
--- a/docs/books/nvchad/install_nvim.md
+++ b/docs/books/nvchad/install_nvim.md
@@ -99,7 +99,7 @@ As with Vim, Neovim requires a basic knowledge of its commands and options. You 
     We first install the packages required for compilation:
 
     ```bash
-    dnf install ninja-build libtool autoconf automake cmake gcc gcc-c++ make pkgconfig unzip patch gettext curl git
+    dnf install --enablerepo=crb ninja-build libtool autoconf automake cmake gcc gcc-c++ make pkgconfig unzip patch gettext curl git
     ```
 
     Once we have installed the necessary packages, we need to create a folder to build neovim from and change into it:


### PR DESCRIPTION
on rocky linux crb repo is required to install ninja-build package

#### Author checklist (Completed by original Author)
- [X] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [X] If applicable, steps and instructions have been tested to work
- [X] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

