### PR TITLE
Update typo in https://docs.rockylinux.org/guides/file_sharing/transmission_daemon/

### DIFF
--- a/docs/guides/file_sharing/transmission_daemon.md
+++ b/docs/guides/file_sharing/transmission_daemon.md
@@ -26,7 +26,7 @@ dnf install -y epel-release
 Then install Transmission:
 
 ```bash
-dnf install -y transmission
+dnf install -y transmission-daemon
 ```
 
 ## First setup

--- a/docs/guides/file_sharing/transmission_daemon.uk.md
+++ b/docs/guides/file_sharing/transmission_daemon.uk.md
@@ -26,7 +26,7 @@ dnf install -y epel-release
 Потім встановіть Transmission:
 
 ```bash
-dnf install -y transmission
+dnf install -y transmission-daemon
 ```
 
 ## Перше налаштування


### PR DESCRIPTION
I noticed when rebuilding my RockyLinux 9 server using Transmission Daemon that:-

```
dnf install -y transmission
```
Should be:-
```
dnf install -y transmission-daemon
```

Current instructions install the client, not the daemon

Regards Tom. 

