### PR TITLE
fixed missing blank lines in blockquotes

### DIFF
--- a/docs/guides/security/firewalld-beginners.md
+++ b/docs/guides/security/firewalld-beginners.md
@@ -148,13 +148,21 @@ If your machine has multiple ways to connect to different networks (e.g., Ethern
 Default zones include the following (I've taken this explanation from [DigitalOcean's guide to `firewalld`](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-8), which you should also read):
 
 > **drop:** The lowest level of trust. All incoming connections are dropped without reply and only outgoing connections are possible.
+
 > **block:** Similar to the above, but instead of simply dropping connections, incoming requests are rejected with an icmp-host-prohibited or icmp6-adm-prohibited message.
+
 > **public:** Represents public, untrusted networks. You don’t trust other computers but may allow selected incoming connections on a case-by-case basis.
+
 > **external:** External networks in the event that you are using the firewall as your gateway. It is configured for NAT masquerading so that your internal network remains private but reachable.
+
 > **internal:** The other side of the external zone, used for the internal portion of a gateway. The computers are fairly trustworthy, and some additional services are available.
+
 > **dmz:** Used for computers located in a DMZ (isolated computers that will not have access to the rest of your network). Only certain incoming connections are allowed.
+
 > **work:** Used for work machines. Trust most of the computers in the network. A few more services might be allowed.
+
 > **home:** A home environment. It generally implies that you trust most of the other computers and that a few more services will be accepted.
+
 > **trusted:** Trust all of the machines in the network. The most open of the available options and should be used sparingly.
 
 Okay, so some of those explanations get complicated, but honestly? The average beginner can get by with understanding "trusted", "home", and "public", and when to use which.


### PR DESCRIPTION
In firewalld-beginners.md, the lack of blank lines in the list of blockquotes breaks the correct display.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

