### PR TITLE
fixed a keyboard shortcut - lab9-cryptography

### DIFF
--- a/docs/labs/security/lab9-cryptography.md
+++ b/docs/labs/security/lab9-cryptography.md
@@ -977,7 +977,7 @@ The public is stored in a file with the same file name as the private key but wi
     Created directory '/home/ying/.ssh'.
     ```
 
-    You'll be prompted twice to enter a passphrase. Input a good and reasonably difficult to guess passphrase. Press <kbd>ENTER</kbd> after each prompt.
+    You'll be prompted twice to enter a passphrase. Input a good and reasonably difficult to guess passphrase. Press ++enter++ after each prompt.
 
     ```bash
     Enter passphrase (empty for no passphrase):     *****


### PR DESCRIPTION
The shortcut was still encoded using the old method `<kbd>..</kbd>`

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

