### PR TITLE
Fix scp command string in admonition `lab-cryptography.md`

### DIFF
--- a/docs/labs/security/lab9-cryptography.md
+++ b/docs/labs/security/lab9-cryptography.md
@@ -905,12 +905,16 @@ usage: scp [-346BCpqrTv] [-c cipher] [-F ssh_config] [-i identity_file]
     !!! Question
 
         What is the difference between the variations of these 2 commands and under what circumstances will they have the same result?
-        
-        - scp me@serverPR:/home/me/myexport.
+    
+        ```bash
+        scp me@serverPR:/home/me/myexport .
+        ```
 
         and
 
-        - scp serverPR:/home/me/myexport.
+        ```bash
+        scp serverPR:/home/me/myexport .
+        ```
 
 5. What is the command to copy over all the files under “/home/me/.gnugp/” on serverPR?
 
@@ -930,11 +934,15 @@ usage: scp [-346BCpqrTv] [-c cipher] [-F ssh_config] [-i identity_file]
 
         What is the slight but significant difference between the variations of the 2 previous commands? And what is the result of each command?
         
-        - `scp -r  ying@localhost:/home/ying/  ying_home_directory_on_serverPR`
-        
+        ```bash
+        scp -r  ying@localhost:/home/ying/  ying_home_directory_on_serverPR
+        ```
+
         and
         
-        -  `scp -r  ying@localhost:/home/ying  ying_home_directory_on_serverPR`
+        ```bash
+        scp -r  ying@localhost:/home/ying  ying_home_directory_on_serverPR
+        ```
 
 8. Use `ls -alR` command to view a listing of the contents of the 2 previous steps. Type:
 


### PR DESCRIPTION
* fix code blocks, because the code was not in code blocks, the period was auto-moved to remove the space. This made the code incorrect.
* fixed another code block nearby

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [ ] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

