### PR TITLE
fix rsync module name in add_mirror_manager.md

### DIFF
--- a/docs/guides/mirror_management/add_mirror_manager.md
+++ b/docs/guides/mirror_management/add_mirror_manager.md
@@ -15,7 +15,7 @@ Please note that we cannot accept public mirrors in countries subject to US expo
 
 As of this writing (late 2022), storage space requirements for mirroring all current and past Rocky Linux releases is about 2 TB.
 
-Our master mirror is `rsync://msync.rockylinux.org/rocky/mirror/pub/rocky/`.
+Our master mirror is `rsync://msync.rockylinux.org/rocky-linux`.
 For your first synchronization use a mirror near to you. You can find all official mirrors [here](https://mirrors.rockylinux.org).
 
 Please note that we might restrict access to the official master mirror to official public mirrors in the future. So please consider `rsyncing` from a public mirror close to you if you are running a private mirror. Also local mirrors might be faster to sync from.


### PR DESCRIPTION
As in mattermost Infrastructure channel, Louis Abel @label and @NeilHanlon mentioned the rsync module name of rockylinux has been changed to rocky-linux

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

