### PR TITLE
Fix vsftpd(en) docs for chroot_local_user typo

### DIFF
--- a/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
+++ b/docs/guides/file_sharing/secure_ftp_server_vsftpd.md
@@ -78,7 +78,7 @@ Ensure that "write_enable" is yes also:
 write_enable=YES
 ```
 
-Find the line to "chroot_local_users" and remove the remark. Add two lines after that shown here:
+Find the line to "chroot_local_user" and remove the remark. Add two lines after that shown here:
 
 ```bash
 chroot_local_user=YES


### PR DESCRIPTION
- Fixed typo in EN version.

This is a rebased and cleaned-up version of the previous PR #2871.
Thanks!

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

