### PR TITLE
podman_guide: Add note about firewall

### DIFF
--- a/docs/guides/containers/podman_guide.md
+++ b/docs/guides/containers/podman_guide.md
@@ -102,6 +102,10 @@ Run a [Nextcloud](https://nextcloud.com/) self-hosted cloud platform as an examp
 podman run -d -p 8080:80 nextcloud
 ```
 
+!!! note
+
+    Out of the box, Rocky Linux has `firewalld` enabled, and may block port 8080. Follow [the guide](../../security/firewalld-beginners/) to open up the port in order to be able to access the service.
+
 You will receive a prompt to select the container registry to download from. In our example, you will use `docker.io/library/nextcloud:latest`.
 
 Once you have downloaded the Nextcloud image, it will run.


### PR DESCRIPTION
Add a note reminding the reader that in order for their container service to be useful, firewall settings may need to be adjusted.

I'm a Debian native so I found having a firewall enabled by default non-obvious, and I thought a note might save some head-scratching from other unwashed like myself who are trying to come over to the light side.

**Note**: I included a link to the firewalld-for-beginners guide but I'm not sure what that's going to look like rendered. Not sure if I went up the right number of `..`s.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

