### PR TITLE
Update docker install documentation for RH 10

### DIFF
--- a/docs/gemstones/containers/docker.md
+++ b/docs/gemstones/containers/docker.md
@@ -13,10 +13,14 @@ The Docker Engine can run native Docker-style container workloads on Rocky Linux
 
 ## Add the Docker repository
 
+!!! Note
+
+    Docker v28 does not currently have a RHEL 10 repository, therefore we will use the CentOS repository.
+
 Use the `dnf` utility to add the Docker repository to your Rocky Linux server. Type:
 
 ```bash
-sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 ```
 
 ## Install the needed packages


### PR DESCRIPTION
Updating docker install documentation to reflect absence of RHEL 10 docker release. Solution is to use the CentOS repository. Associated issue is: https://github.com/rocky-linux/documentation/issues/2854

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

