### PR TITLE
Update OpenZFS repository URL to version 2-8

### DIFF
--- a/docs/books/incus_server/01-install.md
+++ b/docs/books/incus_server/01-install.md
@@ -32,7 +32,7 @@ If there were kernel updates during the upgrade process, reboot the server.
 Install the OpenZFS repository with:
 
 ```bash
-dnf install https://zfsonlinux.org/epel/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
+dnf install https://zfsonlinux.org/epel/zfs-release-2-8$(rpm --eval "%{dist}").noarch.rpm
 ```
 
 ## Install `dkms`, `vim`, and `kernel-devel`

--- a/docs/books/lxd_server/01-install.md
+++ b/docs/books/lxd_server/01-install.md
@@ -29,12 +29,12 @@ dnf upgrade
 
 If there were any kernel updates during the upgrade process, reboot the server.
 
-### OpenZFS repository for 8 and 9
+### OpenZFS repository
 
 Install the OpenZFS repository with:
 
 ```bash
-dnf install https://zfsonlinux.org/epel/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
+dnf install https://zfsonlinux.org/epel/zfs-release-2-8$(rpm --eval "%{dist}").noarch.rpm
 ```
 
 ## Install `snapd`, `dkms`, `vim`, and `kernel-devel`


### PR DESCRIPTION
This PR updates the OpenZFS installation instructions to use the `zfs-release-2-8` repository URL instead of `zfs-release-2-2`.

### Changes
- Updated OpenZFS repository installation command from `zfs-release-2-2` to `zfs-release-2-8`
- Removed version-specific references from section headings

### References
- [OpenZFS Documentation - RHEL-based distro](https://openzfs.github.io/openzfs-docs/Getting%20Started/RHEL-based%20distro/index.html)
- [OpenZFS Issue #17452](https://github.com/openzfs/zfs/issues/17452#issuecomment-3202415782)

### Testing
Verified successful installation of ZFS DKMS modules 2.2.8-1 in a VM on:
- Rocky Linux 8.10
- Rocky Linux 9.6
- Rocky Linux 10.0

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

