### PR TITLE
docs: Update remi-release from 9 to 10, and php-fpm version to latest.

### DIFF
--- a/docs/guides/web/caddy.md
+++ b/docs/guides/web/caddy.md
@@ -156,7 +156,7 @@ It should have an SSL padlock that should work in every modern browser, and not 
 
 As mentioned earlier, Caddy supports FastCGI support for PHP. The good news is that unlike Apache and Nginx, Caddy handles PHP file extensions automatically.
 
-To install PHP, first add the Remi repository (note: if you are running Rocky Linux 8.x or 10.x, substitute in 8 or 10 next to the "release-" below):
+To install PHP, first add the Remi repository (note: if you are running Rocky Linux 8.x or 9.x, substitute in 8 or 9 next to the "release-" below):
 
 ```bash
 sudo dnf install https://rpms.remirepo.net/enterprise/remi-release-10.rpm

--- a/docs/guides/web/caddy.md
+++ b/docs/guides/web/caddy.md
@@ -159,13 +159,13 @@ As mentioned earlier, Caddy supports FastCGI support for PHP. The good news is t
 To install PHP, first add the Remi repository (note: if you are running Rocky Linux 8.x or 10.x, substitute in 8 or 10 next to the "release-" below):
 
 ```bash
-sudo dnf install https://rpms.remirepo.net/enterprise/remi-release-9.rpm
+sudo dnf install https://rpms.remirepo.net/enterprise/remi-release-10.rpm
 ```
 
 Next, we need to install PHP (note: if you are using another version of PHP, substitute your desired version for php83):
 
 ```bash
-sudo dnf install -y php83-php-fpm
+sudo dnf install -y php85-php-fpm
 ```
 
 If you require additional PHP modules (e.g., GD), add them to the above command.
@@ -173,13 +173,13 @@ If you require additional PHP modules (e.g., GD), add them to the above command.
 Then, we need to configure PHP to listen on a TCP socket:
 
 ```bash
-sudo vim /etc/opt/remi/php83/php-fpm.d/www.conf
+sudo vim /etc/opt/remi/php85/php-fpm.d/www.conf
 ```
 
 Next, find the line:
 
 ```bash
-listen = /var/opt/remi/php83/run/php-fpm/www.sock
+listen = /var/opt/remi/php85/run/php-fpm/www.sock
 ```
 
 Replace it with this:
@@ -191,7 +191,7 @@ listen = 127.0.0.1:9000
 We can now enable and start php-fpm:
 
 ```bash
-sudo systemctl enable --now php83-php-fpm
+sudo systemctl enable --now php85-php-fpm
 ```
 
 Then save and exit the `www.conf` file, and open the Caddyfile:


### PR DESCRIPTION
Updated this for Rocky linux 10, however the current text "(note: if you are running Rocky Linux 8.x or 10.x, substitute in 8 or 10 next to the "release-" below):" may be sufficient already. I updated php-fpm aswell, as latest versions are in my opinion better, in order to avoid using potentially vulnerability-prone 

#### Author checklist (Completed by original Author)
- [ ] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [ ] Initial self-review to fix basic typos and grammar completed

(I don't per se know what to do with that checklist especially with the first since I am not the original author of the guide, and with the third one I didn't make any language changes, I only updated versions)

#### Rocky Documentation checklist (Completed by Rocky team) 
- [ ] 1st Pass (Document is good fit for project and author checklist completed)
- [ ] 2nd Pass (Technical Review - check for technical correctness) 
- [ ] 3rd Pass (Detailed Editorial Review and Peer Review)
- [ ] Final approval (Final Review)

