### PR TITLE
Fix `.markddownlint.yml` change

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -114,8 +114,8 @@ MD025:
   # Heading level
   level: 1
   # RegExp for matching title in front matter
-  #front_matter_title: "^\\s*title\\s*[:=]"
-  front_matter_title: ""
+  front_matter_title: "^\\s*title\\s*[:=]"
+  #front_matter_title: ""
 
 # MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md026.md
 MD026:


### PR DESCRIPTION
* someone modified the `.markdownlint.yml` file at some point to eliminate the Level 1 heading consideration for the `title:` meta. This was incorrect.

#### Author checklist (Completed by original Author)
- [x] Good fit for the Rocky Linux project? Title and Author Metatags inserted ?
- [x] If applicable, steps and instructions have been tested to work
- [x] Initial self-review to fix basic typos and grammar completed

#### Rocky Documentation checklist (Completed by Rocky team) 
- [x] 1st Pass (Document is good fit for project and author checklist completed)
- [x] 2nd Pass (Technical Review - check for technical correctness) 
- [x] 3rd Pass (Detailed Editorial Review and Peer Review)
- [x] Final approval (Final Review)

