### PR TITLE
ci: test.yml - reduce urlchecker runtime, pin actions and cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,25 +8,76 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: check urls
-        uses: urlstechie/urlchecker-action@master
+        uses: urlstechie/urlchecker-action@v1
         with:
           subfolder: docs
           file_types: .en.md,.md
           include_files: '\/([\w-]+)\.(en\.)?md'
-          exclude_patterns: 'avatars.githubusercontent.com,example.com,your-server-ip,your-server-hostname,nginx-server,apache-server,site1.com,site2.com,site.com,$releasever,proxy.rocky.lan,repo.rocky.lan,zfs-release,$host$request,fileserver.rockylinux.lan,your_fork_name,rundeck.rockylinux.org,manickathan.ch,breakingpitt.es,download.example,192.168,172.16,127.0.0.1,localhost,download.rockylinux.org,cyber.gov.au,herokuapp.com,rpa.st,home.arpa,SERVER_IP,dev.mysql.com,ip_address,github.com,reddit.com/r/rockylinux,planet.i2p,linode.com,server1.rockylinux.lan,docs.rockylinux.lan,developer.download.nvidia.com,azure.microsoft.com,www.gnu.org,www.samba.org,rsync.samba.org,server.kubernetes.local:6443,node-0:$,0.0.0.0:61208,azuremarketplace.microsoft.com,openqa.rockylinux.org,access.redhat.com,repocompare.rockylinux.org,your_ip,IP:11443,$(hostname):8080,ftp.gnu.org,www.digitalneanderthal.com,mirrors.fedoraproject.org,support.brother.com,ftp.gnu.org'
-          # NOTE:(sspencerwire) 2022-10-25, cyber.gov.au added to excludes as a known good URL that will not pass the test. Probably blocking GitHub
-          # NOTE:(sspencerwire) 2024-04-23, the reddit URL and the linode.com URL function fine, and test fine in the URL checker, but then throw errors at the end. The problem has been reported to the upstream package maintainer.
-          # NOTE:(sspencerwire) 2024-09-11, a link to http://developer.download.nvidia.com/compute/cuda/repos/rhel9/$ failed. This is in a slice of code, and is actually correct, but will always fail the check.
-          # NOTE:(sspencerwire) 2024-09-11, azure.microsoft.com/en-us/ has been failing consistently, but loads fine in a browser. They are probably blocking GitHub.
-          # NOTE:(sspencerwire) 2025-03-11, www.gnu.org, www.samba,org, rsync.samba.org, fail consistently with the URL checker but load fine. Added them to the exceptions. Added azuremarketplace.microsoft.com too for frequent failure.
-          # NOTE:(sspencerwire) 2026-04-29, added some testing team URLs to the exclusion list, as well as some updated from contributors for other documents.
+          exclude_patterns: >
+           avatars.githubusercontent.com,
+           example.com,
+           your-server-ip,
+           your-server-hostname,
+           nginx-server,
+           apache-server,
+           site1.com,
+           site2.com,
+           site.com,
+           $releasever,
+           proxy.rocky.lan,
+           repo.rocky.lan,
+           zfs-release,
+           $host$request,
+           fileserver.rockylinux.lan,
+           your_fork_name,
+           rundeck.rockylinux.org,
+           manickathan.ch,
+           breakingpitt.es,
+           download.example,
+           192.168,
+           172.16,
+           127.0.0.1,
+           localhost,
+           download.rockylinux.org,
+           cyber.gov.au,
+           herokuapp.com,
+           rpa.st,
+           home.arpa,
+           SERVER_IP,
+           dev.mysql.com,
+           ip_address,
+           github.com,
+           reddit.com/r/rockylinux,
+           planet.i2p,
+           linode.com,
+           server1.rockylinux.lan,
+           docs.rockylinux.lan,
+           developer.download.nvidia.com,
+           azure.microsoft.com,
+           www.gnu.org,
+           www.samba.org,
+           rsync.samba.org,
+           server.kubernetes.local:6443,
+           node-0:$,0.0.0.0:61208,
+           azuremarketplace.microsoft.com,
+           openqa.rockylinux.org,
+           access.redhat.com,
+           repocompare.rockylinux.org,
+           your_ip,
+           IP:11443,
+           $(hostname):8080,
+           ftp.gnu.org,
+           www.digitalneanderthal.com,
+           mirrors.fedoraproject.org,
+           support.brother.com,
+           www.intel.com
           print_all: false
-          retry_count: 2
-          timeout: 7
+          retry_count: 1
+          timeout: 3
           force_pass: true # Don't block deployment
           save: "output.csv"
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Gather changed markdown files
+        id: changed
+        run: |
+          git fetch origin ${{ github.base_ref }}
+
+          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep -E '^docs/.*\.(md|en\.md)$' \
+            | paste -sd "," -)
+
+          echo "FILES=$FILES" >> $GITHUB_OUTPUT
       - name: check urls
         uses: urlstechie/urlchecker-action@v1
         with:
-          subfolder: docs
+          subfolder: .
           file_types: .en.md,.md
-          include_files: '\/([\w-]+)\.(en\.)?md'
+          include_files: ${{ steps.changed.outputs.FILES }}
           exclude_patterns: >
            avatars.githubusercontent.com,
            example.com,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         env:
           URLS: "${{ needs.test.outputs.URLS }}"
           COUNT_U: "${{ needs.test.outputs.COUNT_U }}"


### PR DESCRIPTION
Reduce URL checker timeouts/retries, pin action versions, and add known failing intel.com domain.