### PR TITLE
ci: enable docs deploy dispatch to docs.rockylinux.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 ---
-name: Build and Deploy (Fastly)
+name: Trigger docs.rockylinux.org deploy
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'rocky-8', 'rocky-9']
   workflow_dispatch:
 
 jobs:
@@ -15,4 +15,5 @@ jobs:
         with:
           token: ${{ secrets.CROSS_REPO_PAT }}
           repository: rocky-linux/docs.rockylinux.org
-          event-type: deploy-staging
+          event-type: deploy-docs
+          client-payload: '{"repo": "${{ github.repository }}", "ref": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

Revives the disabled `deploy.yml` workflow so that merges to this repo immediately trigger a rebuild/deploy of [docs.rockylinux.org](https://docs.rockylinux.org), which now serves from S3 via Fastly (see rocky-linux/docs.rockylinux.org).

Changes vs the old disabled file:
- `event-type` updated `deploy-staging` → `deploy-docs` to match the receiving workflow ([`build-docs.yml`](https://github.com/rocky-linux/docs.rockylinux.org/blob/main/.github/workflows/build-docs.yml))
- Also triggers on `rocky-8` / `rocky-9` pushes; the `production` environment branch policy has been updated to allow these branches
- Adds `client-payload` (repo/ref/sha) for traceability in the receiving run

## Notes
- Uses the existing `CROSS_REPO_PAT` environment secret (from Oct 2024). It will be validated with a manual run after merge and replaced with a fresh fine-grained PAT if it no longer works.
- The Vercel deploy hook (`vercel_main.yml`) is untouched — dual publishing continues until Vercel is decommissioned.
- The receiving workflow keeps its daily scheduled rebuild as a backstop, and its concurrency group collapses rapid merge bursts into at most one running + one queued build.

## Test plan
- [x] Merge, then run the workflow manually (`workflow_dispatch`)
- [x] Confirm a `repository_dispatch` run starts in rocky-linux/docs.rockylinux.org and completes
- [x] Confirm live site `last-modified` refreshes